### PR TITLE
Make scribes threadsafe.

### DIFF
--- a/citest/base/__init__.py
+++ b/citest/base/__init__.py
@@ -14,6 +14,7 @@
 
 
 from scribe import(
+    Doodle,
     Scribable,
     Scribe,
     ScribeClassRegistry,

--- a/citest/base/base_test_case.py
+++ b/citest/base/base_test_case.py
@@ -54,6 +54,7 @@ import unittest
 # Our modules.
 from . import args_util
 from . import html_scribe
+from .scribe import Doodle
 
 
 # If a -log_config is not provided, then use this.
@@ -264,11 +265,13 @@ class BaseTestCase(unittest.TestCase):
         time=datetime.datetime.now().strftime("%d/%m/%Y %H:%M:%S"))
 
     cls._reportScribe = html_scribe.HtmlScribe()
+    out = Doodle(cls._reportScribe)
+    cls._reportScribe.write_begin_html_document(out, title)
+    out.write(
+        '<div class="title">{title}</div>\n'.format(title=title))
+    cls._reportScribe.write_key_html(out)
     cls._reportFile = open('{0}/{1}'.format(dir, filename), 'w')
-    cls._reportFile.write(cls._reportScribe.render_begin_html_document(title))
-    cls._reportFile.write('<div class="title">{title}</div>\n'.format(
-        title=title))
-    cls._reportFile.write(cls._reportScribe.build_key_html())
+    cls._reportFile.write(str(out))
 
   # TODO(ewiseblatt): 20150807
   # This doesnt really belong here. It is here because
@@ -276,7 +279,9 @@ class BaseTestCase(unittest.TestCase):
   @classmethod
   def finishReportScribe(cls):
     """Finish the reporting scribe and close the file."""
-    cls._reportFile.write(cls._reportScribe.render_end_html_document())
+    out = Doodle(cls._reportScribe)
+    cls._reportScribe.write_end_html_document(out)
+    cls._reportFile.write(str(out))
     cls._reportFile.close()
     cls._reportScribe = None
     cls._reportFile = None
@@ -285,7 +290,7 @@ class BaseTestCase(unittest.TestCase):
   # Same concerns as startReportScribe.
   @classmethod
   def report(cls, obj):
-    cls._reportFile.write(cls._reportScribe.render(obj))
+    cls._reportFile.write(cls._reportScribe.render_to_string(obj))
 
   # TODO(ewiseblatt): 20150807
   # Same concerns as startReportScribe.

--- a/citest/base/test_package.py
+++ b/citest/base/test_package.py
@@ -33,7 +33,7 @@ def collect_suites_in_dir(dir):
                   for test_file in test_file_names]
   if not module_names:
     return []
-  
+
   return [unittest.defaultTestLoader.loadTestsFromName(prefix + test_file)
           for test_file in module_names]
 

--- a/citest/json_contract/cardinality_predicate.py
+++ b/citest/json_contract/cardinality_predicate.py
@@ -41,6 +41,24 @@ class CardinalityResult(predicate.PredicateResult):
     raise NotImplemented('{0}.summary_string not implemented.'.format(
             self.__class__))
 
+  def __init__(self, source, count, pred, pred_result, valid=False):
+    super(CardinalityResult, self).__init__(valid)
+    self._source = source
+    self._count = count
+    self._pred = pred
+    self._pred_result = pred_result
+
+  def __str__(self):
+    return '{summary} detail={detail}'.format(
+      summary=self.summary_string(), detail=self._pred_result)
+
+  def __eq__(self, event):
+    return (self.__class__ == event.__class__
+            and self._count == event._count
+            and self._pred == event._pred
+            and self._source == event._source
+            and self._pred_result == event._pred_result)
+
   def _make_scribe_parts(self, scribe):
     count_relation = scribe.part_builder.determine_verified_relation(self)
     result_relation = scribe.part_builder.determine_verified_relation(
@@ -51,31 +69,14 @@ class CardinalityResult(predicate.PredicateResult):
             scribe.part_builder.build_nested_part('Result', self._pred_result,
                                                   relation=result_relation)]
 
-  def __init__(self, source, count, pred, pred_result, valid=False):
-    super(CardinalityResult, self).__init__(valid)
-    self._source = source
-    self._count = count
-    self._pred = pred
-    self._pred_result = pred_result
-
-  def __str__(self):
-    return '{0} detail={1}'.format(self.summary_string(), self._pred_result)
-
-  def __eq__(self, event):
-    return (self.__class__ == event.__class__
-            and self._count == event._count
-            and self._pred == event._pred
-            and self._source == event._source
-            and self._pred_result == event._pred_result)
-
 
 class ConfirmedCardinalityResult(CardinalityResult):
   """Denotes a CardinalityPredicate that was satisfied."""
 
   def __init__(self, source, count, pred, pred_result, valid=True):
       super(ConfirmedCardinalityResult, self).__init__(
-          valid=valid,
-          source=source, count=count, pred=pred, pred_result=pred_result)
+          source=source, count=count, pred=pred, pred_result=pred_result,
+          valid=valid)
 
   def summary_string(self):
     if not self.count:

--- a/citest/json_contract/map_predicate.py
+++ b/citest/json_contract/map_predicate.py
@@ -80,7 +80,8 @@ class MapPredicateResult(predicate.CompositePredicateResult):
     return self._obj_list
 
   @staticmethod
-  def _render_mapping(result_map_attempt, scribe):
+  def _render_mapping(out, result_map_attempt):
+    scribe = out.scribe
     parts = [
       scribe.part_builder.build_input_part(
         name='Object',
@@ -92,7 +93,8 @@ class MapPredicateResult(predicate.CompositePredicateResult):
         value=result_map_attempt.result,
         summary=result_map_attempt.summary)]
 
-    return scribe.render_parts(parts)
+    scribe.render_parts(out, parts)
+
 
   def _make_scribe_parts(self, scribe):
     parts = [

--- a/citest/service_testing/cli_agent.py
+++ b/citest/service_testing/cli_agent.py
@@ -99,7 +99,8 @@ class CliAgentRunError(testable_agent.AgentError):
 
   def _make_scribe_parts(self, scribe):
     return (super(CliAgentRunError, self)._make_scribe_parts(scribe)
-            + [scribe.build_nested_part('Cli Response', self._run_response)])
+            + [scribe.part_builder.build_nested_part('Cli Response',
+                                                     self._run_response)])
 
   def __init__(self, agent, run_response):
     super(CliAgentRunError, self).__init__(run_response.error)

--- a/citest/service_testing/operation_contract.py
+++ b/citest/service_testing/operation_contract.py
@@ -30,8 +30,9 @@ class OperationContract(Scribable):
     return self._contract
 
   def _make_scribe_parts(self, scribe):
-    return [scribe.build_nested_part('Operation', self._operation),
-            scribe.build_nested_part('Contract', self._contract)]
+    return [scribe.part_builder.build_nested_part(
+               'Operation', self._operation),
+            scribe.part_builder.build_nested_part('Contract', self._contract)]
 
   def __init__(self, operation, contract):
     """Construct instance.

--- a/tests/base/html_scribe_test.py
+++ b/tests/base/html_scribe_test.py
@@ -54,32 +54,34 @@ def test_obj_list_to_html(l):
 class HtmlScribeTest(unittest.TestCase):
   def test_string(self):
       scribe = base.html_scribe.HtmlScribe()
-      text = scribe.render('Hello, World!')
-      self.assertEqual('Hello, World!', text)
+      self.assertEqual('Hello, World!',
+                       scribe.render_to_string('Hello, World!'))
 
   def test_simple_object(self):
       obj = TestObject('Hello, World!')
       scribe = base.html_scribe.HtmlScribe()
-      text = scribe.render(obj)
-      self.assertEqual(test_obj_to_html(obj), text)
+      self.assertEqual(test_obj_to_html(obj),
+                       scribe.render_to_string(obj))
 
   def test_object_list(self):
       l = [ TestObject('A'), TestObject('B') ]
       scribe = base.html_scribe.HtmlScribe()
-      text = scribe.render(l)
-      self.assertEqual(test_obj_list_to_html(l), text)
+      self.assertEqual(test_obj_list_to_html(l),
+                       scribe.render_to_string(l))
 
   def test_list_of_list(self):
       innerAB = [ TestObject('A'), TestObject('B') ]
       innerXY = [ TestObject('X'), TestObject('Y') ]
       outer = [innerAB, innerXY]
       scribe = base.html_scribe.HtmlScribe()
-      text = scribe.render(outer)
+
       # Inner HTML will be indented an extra level
       innerAB_html = test_obj_list_to_html(innerAB).replace('\n', '\n  ')
       innerXY_html = test_obj_list_to_html(innerXY).replace('\n', '\n  ')
-      self.assertEqual('<ul>\n  <li> {0}\n  <li> {1}\n</ul>'.format(
-          innerAB_html, innerXY_html), text)
+      self.assertEqual(
+          '<ul>\n  <li> {0}\n  <li> {1}\n</ul>'.format(
+              innerAB_html, innerXY_html),
+          scribe.render_to_string(outer))
 
 
 if __name__ == '__main__':

--- a/tests/gcp_testing/gce_contract_test.py
+++ b/tests/gcp_testing/gce_contract_test.py
@@ -82,7 +82,8 @@ class GceContractTest(unittest.TestCase):
 
     contract = contract_builder.build()
     verification_result = contract.verify()
-    self.assertTrue(verification_result, Scribe().render(verification_result))
+    self.assertTrue(verification_result,
+                    Scribe().render_to_string(verification_result))
 
     command = gcloud.build_gcloud_command_args(
         'instances', ['describe', 'test_name'] + extra_args,

--- a/tests/json_contract/cardinality_predicate_test.py
+++ b/tests/json_contract/cardinality_predicate_test.py
@@ -33,7 +33,8 @@ class CardinalityPredicateTest(unittest.TestCase):
   def assertEqual(self, a, b, msg=''):
     if not msg:
       scribe = Scribe()
-      msg = 'EXPECT\n{0}\nGOT\n{1}'.format(scribe.render(a), scribe.render(b))
+      msg = 'EXPECT\n{0}\nGOT\n{1}'.format(
+        scribe.render_to_string(a), scribe.render_to_string(b))
     super(CardinalityPredicateTest, self).assertEqual(a, b, msg)
 
 

--- a/tests/json_contract/contract_test.py
+++ b/tests/json_contract/contract_test.py
@@ -42,7 +42,8 @@ class JsonContractTest(unittest.TestCase):
   def assertEqual(self, a, b, msg=''):
     if not msg:
       scribe = Scribe()
-      msg = 'EXPECT\n{0}\nGOT\n{1}'.format(scribe.render(a), scribe.render(b))
+      msg = 'EXPECT\n{0}\nGOT\n{1}'.format(
+        scribe.render_to_string(a), scribe.render_to_string(b))
     super(JsonContractTest, self).assertEqual(a, b, msg)
 
   def test_clause_success(self):

--- a/tests/json_contract/map_predicate_test.py
+++ b/tests/json_contract/map_predicate_test.py
@@ -51,7 +51,7 @@ class JsonMapPredicateTest(unittest.TestCase):
     """
     map_result = jc.MapPredicate(pred, min=min)(obj)
     if dump:
-      print 'MAP_RESULT:\n{0}\n'.format(Scribe().render(map_result))
+      print 'MAP_RESULT:\n{0}\n'.format(Scribe().render_to_string(map_result))
 
     if expect_map_result:
       self.assertEqual(

--- a/tests/json_contract/observation_failure_test.py
+++ b/tests/json_contract/observation_failure_test.py
@@ -31,7 +31,7 @@ class ObservationFailureTest(unittest.TestCase):
     if not msg:
       scribe = Scribe()
       msg = 'EXPECT\n{0}\nGOT\n{1}'.format(
-        scribe.render(a), scribe.render(b))
+        scribe.render_to_string(a), scribe.render_to_string(b))
     super(ObservationFailureTest, self).assertEqual(a, b, msg)
 
   def testObservationFailedErrorEqual(self):

--- a/tests/json_contract/observation_verifier_test.py
+++ b/tests/json_contract/observation_verifier_test.py
@@ -49,7 +49,9 @@ class ObservationVerifierTest(unittest.TestCase):
   def assertEqual(self, a, b, msg=''):
     if not msg:
       scribe = Scribe()
-      msg = 'EXPECT\n{0}\nGOT\n{1}'.format(scribe.render(a), scribe.render(b))
+      msg = 'EXPECT\n{0}\nGOT\n{1}'.format(
+        scribe.render_to_string(a),
+        scribe.render_to_string(b))
     super(ObservationVerifierTest, self).assertEqual(a, b, msg)
 
   def test_result_builder_add_good_result(self):

--- a/tests/json_contract/value_observation_verifier_test.py
+++ b/tests/json_contract/value_observation_verifier_test.py
@@ -34,8 +34,8 @@ class JsonValueObservationVerifierTest(unittest.TestCase):
   def assertEqual(self, a, b, msg=''):
     if not msg:
       msg = 'EXPECT\n{0}\nGOT\n{1}'.format(
-        Scribe().render(a),
-        Scribe().render(b))
+        Scribe().render_to_string(a),
+        Scribe().render_to_string(b))
     super(JsonValueObservationVerifierTest, self).assertEqual(a, b, msg)
 
   def test_verifier_builder_add_constraint(self):
@@ -212,10 +212,12 @@ class JsonValueObservationVerifierTest(unittest.TestCase):
     scribe = Scribe()
     error_msg = '{expect_ok}!={ok}\n{errors}'.format(
         expect_ok=expect_ok, ok=ok,
-        errors=scribe.render(verify_results.bad_results))
+        errors=scribe.render_to_string(verify_results.bad_results))
     if dump:
-      print 'GOT RESULTS:\n{0}\n'.format(scribe.render(verify_results))
-      print '\nEXPECTED:\n{0}\n'.format(scribe.render(expect_results))
+      print 'GOT RESULTS:\n{0}\n'.format(
+          scribe.render_to_string(verify_results))
+      print '\nEXPECTED:\n{0}\n'.format(
+          scribe.render_to_string(expect_results))
 
     self.assertEqual(expect_ok, ok, error_msg)
     if expect_results:


### PR DESCRIPTION
Added Doodle object that holds mutable state (level/indentation).
Instead of scribe.render() returning a string, it writes into the
doodle so the doodle also holds output. That changed the API
to most callers.

Different threads would presumably be building their own output buffers.
It's up to the code in those threads to decide if/when/how to coordinate
them (just as any logging mechanism would, only here the interleaving can
be at a coarser granularity to meet the needs of the caller).

Whereas before render calls were in the form:
   (obj_to_render, scribe_to_use)
now they are in the form:
   (doodle_to_write_to, obj_to_render)
where the doodle contains the scribe as an attribute making the
calls simpler. "doodle_to_write_to" is typically called "out" for brevity.
Note that the order of parameters changed so that the output parameter is
first. This is for consistency against different APIs that are writing to
the output but take different types of arguments and argument lists. The output
is always positionally first.

Made HtmlScribe's internal unique id counter threadsafe.

Reordered parameters.
