### PR TITLE
Managed instance groups are now in gcloud compute, not gcloud preview.

### DIFF
--- a/citest/gcp_testing/gce_contract.py
+++ b/citest/gcp_testing/gce_contract.py
@@ -171,8 +171,10 @@ class GCloudClauseBuilder(jc.ContractClauseBuilder):
     self.observer = self._factory.new_inspect_resource(type, name, extra_args)
 
     if no_resource_ok:
+      # Unfortunately gcloud does not surface the actual 404 but prints an
+      # error message saying that it was not found.
       error_verifier = cli_agent.CliAgentObservationFailureVerifier(
-          title='404 Permitted', error_regex='.*ResponseError: code=404.*')
+          title='404 Permitted', error_regex='.* was not found.*')
       disjunction_builder = jc.ObservationVerifierBuilder(
           'Inspect {0} {1} or 404'.format(type, name))
       disjunction_builder.append_verifier(error_verifier)

--- a/tests/gcp_testing/gcloud_agent_test.py
+++ b/tests/gcp_testing/gcloud_agent_test.py
@@ -34,8 +34,14 @@ class GCloudAgentTest(unittest.TestCase):
     gcloud.list_resources('managed-instance-groups')
     self.assertEqual(
       gcloud.last_run_params,
-      ['-q', 'preview'] + standard_params
-      + ['managed-instance-groups', '--zone', 'ZONE', 'list'])
+      ['-q', 'compute'] + standard_params
+      + ['instance-groups', 'managed', 'list', '--zone', 'ZONE'])
+
+    gcloud.list_resources('unmanaged-instance-groups')
+    self.assertEqual(
+      gcloud.last_run_params,
+      ['-q', 'compute'] + standard_params
+      + ['instance-groups', 'unmanaged', 'list', '--zone', 'ZONE'])
 
     gcloud.describe_resource('instances', 'NAME')
     self.assertEqual(gcloud.last_run_params,
@@ -44,9 +50,15 @@ class GCloudAgentTest(unittest.TestCase):
 
     gcloud.describe_resource('managed-instance-groups', 'NAME')
     self.assertEqual(gcloud.last_run_params,
-                     ['-q', 'preview'] + standard_params
-                     + ['managed-instance-groups', '--zone', 'ZONE',
-                        'describe', 'NAME'])
+                     ['-q', 'compute'] + standard_params
+                     + ['instance-groups', 'managed',
+                        'describe', 'NAME', '--zone', 'ZONE'])
+
+    gcloud.describe_resource('unmanaged-instance-groups', 'NAME')
+    self.assertEqual(gcloud.last_run_params,
+                     ['-q', 'compute'] + standard_params
+                     + ['instance-groups', 'unmanaged',
+                        'describe', 'NAME', '--zone', 'ZONE'])
 
 
   def test_gcloud_needs_zone(self):
@@ -86,20 +98,20 @@ class GCloudAgentTest(unittest.TestCase):
     self.assertEqual(
       gt.GCloudAgent.build_gcloud_command_args(
         'managed-instance-groups', ['list', 'X']),
-      ['-q', 'preview', '--format', 'json',
-       'managed-instance-groups', 'list', 'X'])
+      ['-q', 'compute', '--format', 'json',
+       'instance-groups', 'managed', 'list', 'X'])
 
     self.assertEqual(
       gt.GCloudAgent.build_gcloud_command_args(
-        'managed-instance-groups', ['list', 'X'], zone='ZONE'),
-      ['-q', 'preview', '--format', 'json',
-       'managed-instance-groups', '--zone', 'ZONE', 'list', 'X'])
+        'managed-instance-groups', ['list', 'X']),
+      ['-q', 'compute', '--format', 'json',
+       'instance-groups', 'managed', 'list', 'X'])
 
     self.assertEqual(
       gt.GCloudAgent.build_gcloud_command_args(
-        'managed-instance-groups', ['describe', 'X'], zone='ZONE'),
-      ['-q', 'preview', '--format', 'json',
-       'managed-instance-groups', '--zone', 'ZONE', 'describe', 'X'])
+        'managed-instance-groups', ['describe', 'X'], zone='XYZ'),
+      ['-q', 'compute', '--format', 'json',
+       'instance-groups', 'managed', 'describe', 'X', '--zone', 'XYZ'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Depending on your version of gcloud, this may require an update
gcloud components update

But the old support will eventually be dropped, so this change is inevitable and gets rid of the warnings in "newer" versions of gcloud.
