### PR TITLE
Fixed tests.

### DIFF
--- a/spinnaker/spinnaker_system/aws_kato_test.py
+++ b/spinnaker/spinnaker_system/aws_kato_test.py
@@ -12,6 +12,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Sample Usage:
+#     Assuming you have created $PASSPHRASE_FILE (which you should chmod 400):
+#     and $CITEST_ROOT points to the root directory of this repository
+#     (which is . if you execute this from the root)
+#     and $AWS_PROFILE is the name of the aws_cli profile for authenticating
+#     to observe aws resources:
+#
+#     This first command would be used if Spinnaker itself was deployed on GCE.
+#     The test needs to talk to GCE to get to spinnaker (using the gce_* params)
+#     then talk to AWS (using the aws_profile with the aws cli program) to
+#     verify Spinnaker had the right effects on AWS.
+#
+#     PYTHONPATH=$CITEST_ROOT:$CITEST_ROOT/spinnaker \
+#       python $CITEST_ROOT/spinnaker/spinnaker_system/aws_kato_test.py \
+#       --gce_ssh_passphrase_file=$PASSPHRASE_FILE \
+#       --gce_project=$PROJECT \
+#       --gce_zone=$GCE_ZONE \
+#       --gce_instance=$INSTANCE \
+#       --test_aws_zone=$AWS_ZONE \
+#       --aws_profile=$AWS_PROFILE
+#
+#   or
+#
+#     This second command would be used if Spinnaker itself was deployed some
+#     place reachable through a direct IP connection. It could be, but is not
+#     necessarily deployed on GCE. It is similar to above except it does not
+#     need to go through GCE and its firewalls to locate the actual IP endpoints
+#     rather those are already known and accessible.
+#
+#     PYTHONPATH=$CITEST_ROOT:$CITEST_ROOT/spinnaker \
+#       python $CITEST_ROOT/spinnaker/spinnaker_system/aws_kato_test.py \
+#       --native_hostname=host-running-kato
+#       --test_aws_zone=$AWS_ZONE \
+#       --aws_profile=$AWS_PROFILE
+#
+#   Note that the $AWS_ZONE is not directly used, rather it is a standard
+#   parameter being used to infer the region. The test is going to pick
+#   some different availability zones within the region in order to test kato.
+#   These are currently hardcoded in.
+
 import sys
 import time
 

--- a/spinnaker/spinnaker_system/kato_test.py
+++ b/spinnaker/spinnaker_system/kato_test.py
@@ -22,14 +22,18 @@
 #
 # Sample Usage:
 #     Assuming you have created $PASSPHRASE_FILE (which you should chmod 400):
+#     and $CITEST_ROOT points to the root directory of this repository
+#     (which is . if you execute this from the root)
 #
-#   python test/kato_test.py \
+#   PYTHONPATH=$CITEST_ROOT:$CITEST_ROOT/spinnaker \
+#     python $CITEST_ROOT/spinnaker/spinnaker_system/kato_test.py \
 #     --gce_ssh_passphrase_file=$PASSPHRASE_FILE \
 #     --gce_project=$PROJECT \
 #     --gce_zone=$ZONE \
 #     --gce_instance=$INSTANCE
 # or
-#   python test/kato_test.py \
+#   PYTHONPATH=$CITEST_ROOT:$CITEST_ROOT/spinnaker \
+#     python $CITEST_ROOT/spinnaker/spinnaker_system/kato_test.py \
 #     --native_hostname=host-running-kato
 #     --managed_gce_project=$PROJECT \
 #     --test_gce_zone=$ZONE

--- a/spinnaker/spinnaker_testing/gate.py
+++ b/spinnaker/spinnaker_testing/gate.py
@@ -152,8 +152,7 @@ class GateAgent(sk.SpinnakerAgent):
       application=application)
 
     return self.new_post_operation(
-            title='create_app', data=payload,
-            path='applications/{name}/tasks'.format(name=application))
+            title='create_app', data=payload, path='tasks')
 
   def make_delete_app_operation(self, bindings, application):
     """Create a Gate operation that will delete an existing application.
@@ -177,8 +176,7 @@ class GateAgent(sk.SpinnakerAgent):
       application=application)
 
     return self.new_post_operation(
-            title='delete_app', data=payload,
-            path='applications/{name}/tasks'.format(name=application))
+            title='delete_app', data=payload, path='tasks')
 
 
 def new_agent(bindings, port=8084):

--- a/spinnaker/spinnaker_testing/spinnaker.py
+++ b/spinnaker/spinnaker_testing/spinnaker.py
@@ -393,21 +393,19 @@ class SpinnakerAgent(service_testing.HttpAgent):
 
     spinnaker_config = {
       # Assume the default name.
-      'ACCOUNT_NAME': 'my-account-name',
+      'GOOGLE_ACCOUNT_NAME': 'my-account-name',
       # Assume the default managed project is itself.
-      'MANAGED_PROJECT_ID': gcloud.project
+      'GOOGLE_MANAGED_PROJECT_ID': gcloud.project
     }
 
     logger = logging.getLogger(__name__)
-    for key in ['MANAGED_PROJECT_ID', 'ACCOUNT_NAME']:
+    for key in ['GOOGLE_MANAGED_PROJECT_ID', 'GOOGLE_ACCOUNT_NAME']:
       m = re.search(key + '=([-\w]+)', contents)
       if m:
         spinnaker_config[key] = m.group(1)
       else:
         logger.debug(
           'Seems to be using the default %s=%s', key, spinnaker_config[key])
-    spinnaker_config['MANAGED_GCE_PROJECT'] = (
-      spinnaker_config['MANAGED_PROJECT_ID'])
 
     logger.debug('Collected configuration %s', spinnaker_config)
     return spinnaker_config

--- a/spinnaker/spinnaker_testing/spinnaker_test_scenario.py
+++ b/spinnaker/spinnaker_testing/spinnaker_test_scenario.py
@@ -140,9 +140,15 @@ class SpinnakerTestScenario(sk.AgentTestScenario):
     self._bindings['TEST_AWS_REGION'] = self._bindings['TEST_AWS_ZONE'][:-1]
     self._update_bindings_with_subsystem_configuration(agent)
 
-    if self._bindings.get('MANAGED_GCE_PROJECT'):
+    # !!! DEPRECATED(20150921)
+    if not self._bindings.get('GOOGLE_MANAGED_PROJECT_ID'):
+      self._bindings['GOOGLE_MANAGED_PROJECT_ID'] =  self._bindings.get('MANAGED_GCE_PROJECT', '')
+    if not self._bindings.get('GOOGLE_ACCOUNT_NAME'):
+      self._bindings['GOOGLE_ACCOUNT_NAME'] =  self._bindings.get('ACCOUNT_NAME', '')
+
+    if self._bindings.get('GOOGLE_MANAGED_PROJECT_ID'):
       self._gce_observer = gcp.GCloudAgent(
-          project=self._bindings['MANAGED_GCE_PROJECT'],
+          project=self._bindings['GOOGLE_MANAGED_PROJECT_ID'],
           zone=self._bindings['TEST_GCE_ZONE'],
           ssh_passphrase_file=self._bindings['GCE_SSH_PASSPHRASE_FILE'])
     else:
@@ -173,13 +179,13 @@ class SpinnakerTestScenario(sk.AgentTestScenario):
 
     if not self._bindings['GCE_CREDENTIALS']:
       self._bindings['GCE_CREDENTIALS'] = self._bindings.get(
-          'ACCOUNT_NAME', None)
+          'GOOGLE_ACCOUNT_NAME', None)
 
-    if not self._bindings.get('MANAGED_GCE_PROJECT'):
+    if not self._bindings.get('GOOGLE_MANAGED_PROJECT_ID'):
       # Default to the project we are managing.
-      self._bindings['MANAGED_GCE_PROJECT'] = agent.runtime_config.get(
-          'MANAGED_PROJECT_ID')
-      if not self._bindings['MANAGED_GCE_PROJECT']:
+      self._bindings['GOOGLE_MANAGED_PROJECT_ID'] = agent.runtime_config.get(
+          'GOOGLE_MANAGED_PROJECT_ID')
+      if not self._bindings['GOOGLE_MANAGED_PROJECT_ID']:
         # But if that wasnt defined then default to the subsystem's project.
-        self._bindings['MANAGED_GCE_PROJECT'] = self._bindings['GCE_PROJECT']
+        self._bindings['GOOGLE_MANAGED_PROJECT_ID'] = self._bindings['GCE_PROJECT']
         


### PR DESCRIPTION
This wont work using the old deployment scripts because in the new refactored
scripts (in spinnaker/google) I changed configuration names that the tests use
here. Since the tests were broken and I want people to migrate to the new
deployment scripts, I'm not keeping backward compatability here.

The fixes for the tests themselves were migrating to the refactored schema
changes. I'm not entirely sure what the current correct schemas are. The
values I'm passing were scraped from current Deck messages. The tests pass.
However, there are redundant values that look like a state of transition.

I also changed submitting gate requests from /application/{name}/tasks to
/tasks because the gate controller suggested that /application was deprecated
in favor of /tasks.
