### PR TITLE
Handle process-level test errors.

### DIFF
--- a/citest/base/base_test_case.py
+++ b/citest/base/base_test_case.py
@@ -363,13 +363,18 @@ class BaseTestCase(unittest.TestCase):
   def main(cls, scenarioClass=BaseTestScenario):
     cls.setupScenario(scenarioClass)
 
-    # Create some separation in logs
-    logger = logging.getLogger(__name__)
-    logger.info('Finished Setup. Start Tests\n'
-                + ' ' * (8 + 1)  # for leading timestamp prefix
-                + '---------------------------\n')
+    try:
+      # Create some separation in logs
+      logger = logging.getLogger(__name__)
+      logger.info('Finished Setup. Start Tests\n'
+                  + ' ' * (8 + 1)  # for leading timestamp prefix
+                  + '---------------------------\n')
 
-    suite = cls.buildSuite()
-    unittest.TextTestRunner(verbosity=2).run(suite)
+      suite = cls.buildSuite()
+      result = unittest.TextTestRunner(verbosity=2).run(suite)
+    finally:
+      if sys.exc_info()[0] != None:
+        sys.stderr.write('Tearing down scenario early due to an exception\n')
+      cls.teardownScenario(scenarioClass)
 
-    cls.teardownScenario(scenarioClass)
+    return len(result.failures) + len(result.errors)

--- a/citest/service_testing/agent_test_case.py
+++ b/citest/service_testing/agent_test_case.py
@@ -233,4 +233,4 @@ class AgentTestCase(base.BaseTestCase):
   def main(cls, scenarioClass):
     if not issubclass(scenarioClass, AgentTestScenario):
       raise Exception('scenarioClass must be derived from AgentTestScenario.')
-    super(AgentTestCase, cls).main(scenarioClass)
+    return super(AgentTestCase, cls).main(scenarioClass)

--- a/spinnaker/spinnaker_system/aws_kato_test.py
+++ b/spinnaker/spinnaker_system/aws_kato_test.py
@@ -84,7 +84,7 @@ class AwsKatoTestScenario(sk.SpinnakerTestScenario):
     # Local test
     parser.add_argument(
         '--test_image_name',
-        default='ubuntu-1404-trusty-v20150316',
+        default='ubuntu-1404-trusty-v20150909a',
         help='Image name to use when creating test instance.')
     parser.add_argument(
         '--test_stack', default='awstest', help='Spinnaker stack decorator.')
@@ -201,9 +201,9 @@ class AwsKatoIntegrationTest(st.AgentTestCase):
 
 
 def main():
-    AwsKatoIntegrationTest.main(AwsKatoTestScenario)
+  return AwsKatoIntegrationTest.main(AwsKatoTestScenario)
 
 
 if __name__ == '__main__':
-  main()
-  sys.exit(0)
+  result = main()
+  sys.exit(result)

--- a/spinnaker/spinnaker_system/kato_test.py
+++ b/spinnaker/spinnaker_system/kato_test.py
@@ -103,7 +103,7 @@ class KatoTestScenario(sk.SpinnakerTestScenario):
     # TODO(ewiseblatt): Move this image name somewhere.
     parser.add_argument(
         '--test_gce_image_name',
-        default='ubuntu-1404-trusty-v20150805',
+        default='ubuntu-1404-trusty-v20150909a',
         help='Image name to use when creating test instance on GCE.')
 
   def __init__(self, bindings, agent):
@@ -581,9 +581,10 @@ class KatoIntegrationTest(st.AgentTestCase):
 
 
 def main():
-  KatoIntegrationTest.main(KatoTestScenario)
+  return KatoIntegrationTest.main(KatoTestScenario)
 
 
 if __name__ == '__main__':
-  main()
-  sys.exit(0)
+  result = main()
+  sys.exit(result)
+

--- a/spinnaker/spinnaker_system/smoke_test.py
+++ b/spinnaker/spinnaker_system/smoke_test.py
@@ -235,7 +235,7 @@ class SmokeTestScenario(sk.SpinnakerTestScenario):
           'capacity': {'min':2, 'max':2, 'desired':2},
           'initialNumReplicas': 2,
           'providerType': 'gce',
-          'image': 'ubuntu-1404-trusty-v20150316',
+          'image': 'ubuntu-1404-trusty-v20150909a',
           'zone': bindings['TEST_GCE_ZONE'], 'stack': bindings['TEST_STACK'],
           'instanceType': 'f1-micro',
           'type': 'linearDeploy',
@@ -332,9 +332,9 @@ class SmokeTest(st.AgentTestCase):
 
 
 def main():
-  SmokeTest.main(SmokeTestScenario)
+  return SmokeTest.main(SmokeTestScenario)
 
 
 if __name__ == '__main__':
-  main()
-  sys.exit(0)
+  result = main()
+  sys.exit(result)

--- a/spinnaker/spinnaker_testing/spinnaker_test_scenario.py
+++ b/spinnaker/spinnaker_testing/spinnaker_test_scenario.py
@@ -26,12 +26,13 @@ class SpinnakerTestScenario(sk.AgentTestScenario):
     return http_agent.HttpPostOperation(title=title, data=data, path=path)
 
   @classmethod
-  def initArgumentParser(cls, parser, subsystem_name):
+  def initArgumentParser(cls, parser, subsystem_name='the server'):
     """Initialize command line argument parser.
 
     Args:
       parser: argparse.ArgumentParser
-      subsystem_name: The name of the subsystem we're testing.
+      subsystem_name: The name of the subsystem we're testing is used to
+         customize help messages for the argument parser.
     """
     super(SpinnakerTestScenario, cls).initArgumentParser(parser)
 


### PR DESCRIPTION
Tests currently return 0 rather than non-0 on error.
This changes the test return result to be non-0 on error
(value is #failures + #errors but that isnt officially defined yet)

Also, force cleanupScenario to be called on exceptions too.

Made two unrelated changes while I was here:
Updated spinnaker images to the most current ubuntu (not a long term solution).
Gave default value to spinnaker initArgumentParser system name so that this
  isnt actually required.
