### PR TITLE
Updated spinnaker tests for PRIMARY credential decorator.

### DIFF
--- a/spinnaker/spinnaker_testing/spinnaker.py
+++ b/spinnaker/spinnaker_testing/spinnaker.py
@@ -393,13 +393,14 @@ class SpinnakerAgent(service_testing.HttpAgent):
 
     spinnaker_config = {
       # Assume the default name.
-      'GOOGLE_ACCOUNT_NAME': 'my-account-name',
+      'GOOGLE_PRIMARY_ACCOUNT_NAME': 'my-account-name',
       # Assume the default managed project is itself.
-      'GOOGLE_MANAGED_PROJECT_ID': gcloud.project
+      'GOOGLE_PRIMARY_MANAGED_PROJECT_ID': gcloud.project
     }
 
     logger = logging.getLogger(__name__)
-    for key in ['GOOGLE_MANAGED_PROJECT_ID', 'GOOGLE_ACCOUNT_NAME']:
+    for key in ['GOOGLE_PRIMARY_MANAGED_PROJECT_ID',
+                'GOOGLE_PRIMARY_ACCOUNT_NAME']:
       m = re.search(key + '=([-\w]+)', contents)
       if m:
         spinnaker_config[key] = m.group(1)

--- a/spinnaker/spinnaker_testing/spinnaker_test_scenario.py
+++ b/spinnaker/spinnaker_testing/spinnaker_test_scenario.py
@@ -83,9 +83,10 @@ class SpinnakerTestScenario(sk.AgentTestScenario):
 
     parser.add_argument(
         '--gce_credentials',
-        default='my-account-name',
+        default='',
         help='Spinnaker account name to use for test operations.'
-             ' Only used when managing jobs running on GCE.')
+             ' Only used when managing jobs running on GCE.'
+             ' If left empty then use the configured primary account.')
 
     # AWS stuff
     parser.add_argument(
@@ -142,14 +143,14 @@ class SpinnakerTestScenario(sk.AgentTestScenario):
     self._update_bindings_with_subsystem_configuration(agent)
 
     # !!! DEPRECATED(20150921)
-    if not self._bindings.get('GOOGLE_MANAGED_PROJECT_ID'):
-      self._bindings['GOOGLE_MANAGED_PROJECT_ID'] =  self._bindings.get('MANAGED_GCE_PROJECT', '')
-    if not self._bindings.get('GOOGLE_ACCOUNT_NAME'):
-      self._bindings['GOOGLE_ACCOUNT_NAME'] =  self._bindings.get('ACCOUNT_NAME', '')
+    if not self._bindings.get('GOOGLE_PRIMARY_MANAGED_PROJECT_ID'):
+      self._bindings['GOOGLE_PRIMARY_MANAGED_PROJECT_ID'] = self._bindings.get('MANAGED_GCE_PROJECT', '') or self._bindings.get('GOOGLE_MANAGED_PROJECT_ID')
+    if not self._bindings.get('GOOGLE_PRIMARY_ACCOUNT_NAME'):
+      self._bindings['GOOGLE_PRIMARY_ACCOUNT_NAME'] = self._bindings.get('ACCOUNT_NAME', '') or self._bindings.get('GOOGLE_ACCOUNT_NAME', '')
 
-    if self._bindings.get('GOOGLE_MANAGED_PROJECT_ID'):
+    if self._bindings.get('GOOGLE_PRIMARY_MANAGED_PROJECT_ID'):
       self._gce_observer = gcp.GCloudAgent(
-          project=self._bindings['GOOGLE_MANAGED_PROJECT_ID'],
+          project=self._bindings['GOOGLE_PRIMARY_MANAGED_PROJECT_ID'],
           zone=self._bindings['TEST_GCE_ZONE'],
           ssh_passphrase_file=self._bindings['GCE_SSH_PASSPHRASE_FILE'])
     else:
@@ -180,13 +181,13 @@ class SpinnakerTestScenario(sk.AgentTestScenario):
 
     if not self._bindings['GCE_CREDENTIALS']:
       self._bindings['GCE_CREDENTIALS'] = self._bindings.get(
-          'GOOGLE_ACCOUNT_NAME', None)
+          'GOOGLE_PRIMARY_ACCOUNT_NAME', None)
 
-    if not self._bindings.get('GOOGLE_MANAGED_PROJECT_ID'):
+    if not self._bindings.get('GOOGLE_PRIMARY_MANAGED_PROJECT_ID'):
       # Default to the project we are managing.
-      self._bindings['GOOGLE_MANAGED_PROJECT_ID'] = agent.runtime_config.get(
-          'GOOGLE_MANAGED_PROJECT_ID')
-      if not self._bindings['GOOGLE_MANAGED_PROJECT_ID']:
+      self._bindings['GOOGLE_PRIMARY_MANAGED_PROJECT_ID'] = agent.runtime_config.get(
+          'GOOGLE_PRIMARY_MANAGED_PROJECT_ID')
+      if not self._bindings['GOOGLE_PRIMARY_MANAGED_PROJECT_ID']:
         # But if that wasnt defined then default to the subsystem's project.
-        self._bindings['GOOGLE_MANAGED_PROJECT_ID'] = self._bindings['GCE_PROJECT']
-        
+        self._bindings['GOOGLE_PRIMARY_MANAGED_PROJECT_ID'] = self._bindings['GCE_PROJECT']
+


### PR DESCRIPTION
@duftler or @ttomsu 
This corresponds to the spinnaker configuration PR.
I attempted to continue to preserve backward compatability for travis on the old scripts, but have not tested that. I'm going to rip the deprecated compatability statements out once he migrates.
