### PR TITLE
Added load_balancer_delete retry to fix kato test.

### DIFF
--- a/spinnaker/spinnaker_system/kato_test.py
+++ b/spinnaker/spinnaker_system/kato_test.py
@@ -526,7 +526,8 @@ class KatoIntegrationTest(st.AgentTestCase):
 
   def test_v_delete_http_load_balancer(self):
     self.run_test_case(
-        self.scenario.delete_http_load_balancer(), timeout_ok=True)
+        self.scenario.delete_http_load_balancer(), timeout_ok=True,
+        retry_interval_secs=10, max_retries=9)
 
   def test_w_deregister_load_balancer_instances(self):
     self.run_test_case(self.scenario.deregister_load_balancer_instances())


### PR DESCRIPTION
@duftler 
This should fix the failing kato test. However I am not sure why it has become "not ready" to delete in the first place. I dont know if this is a GCE problem or some other aspect that takes a long time to initialize and the creation test wasnt looking for or waiting on it. It would be nice if there were more context with the error. The stack trace is purely coming out of GCE so it is likely a condition known to clouddriver.
