### PR TITLE
Remove dependency on requests package.

### DIFF
--- a/spinnaker/spinnaker_system/bake_and_deploy_test.py
+++ b/spinnaker/spinnaker_system/bake_and_deploy_test.py
@@ -108,7 +108,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
       '--jenkins_job', default='TestTriggerProject',
       help='The name of the jenkins job to trigger off.')
     parser.add_argument(
-      '--jenkins_auth_path',
+      '--jenkins_auth_path', default=None,
       help='The path to a file containing the jenkins username password pair.'
            'The contents should look like: <username> <password>.' )
     parser.add_argument(
@@ -188,7 +188,6 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
       job=[{
           'cloudProvider': 'gce',
           'provider': 'gce',
-          'providerType': 'gce',
           'stack': bindings['TEST_STACK'],
           'detail': self.__short_lb_name,
           'credentials': bindings['GCE_CREDENTIALS'],
@@ -544,7 +543,7 @@ class BakeAndDeployTest(st.AgentTestCase):
 
   def test_z_delete_app(self):
     if not self.scenario.run_tests:
-      unitest.skipTest("No --test_{google, aws} flags were set")
+      self.skipTest("No --test_{google, aws} flags were set")
     # Give a total of a minute because it might also need
     # an internal cache update
     self.run_test_case(self.scenario.delete_app(),


### PR DESCRIPTION
Only used for convienence of Basic Authentication but isnt always part of 2.7
so added Basic Authentication support to Http Agent using urllib2.

Refactored HttpAgent so it takes a baseUrl instead of host/port.

The BakeAndDeploy test isnt working, but seems unrelated to this change because
it seems that the Jenkins trigger is working, but the pipeline execution doesnt
start. I suspect the test is broken or making assumptions about the
execution environment.
