### PR TITLE
Comments, formatting, and a bit of cleanup.

### DIFF
--- a/spinnaker/spinnaker_system/bake_and_deploy_test.py
+++ b/spinnaker/spinnaker_system/bake_and_deploy_test.py
@@ -509,7 +509,8 @@ class BakeAndDeployTest(st.AgentTestCase):
   def test_c1_create_bake_and_deploy_google_pipeline(self):
     if not self.scenario.test_google:
       self.skipTest("--test_google flag not set")
-    self.run_test_case(self.scenario.create_bake_and_deploy_google_pipeline())
+    self.run_test_case(self.scenario.create_bake_and_deploy_google_pipeline(),
+                       full_trace=True)
 
   def test_c2_create_bake_and_deploy_aws_pipeline(self):
     if not self.scenario.test_aws:

--- a/spinnaker/spinnaker_testing/expression_dict.py
+++ b/spinnaker/spinnaker_testing/expression_dict.py
@@ -12,47 +12,87 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""A dictionary that can resolve values from other fields."""
+"""A dictionary that can resolve values from other keys."""
 
 import re
 
 
 class ExpressionDict(dict):
+  """A specialization of dict where key values can reference other entries.
+
+  The dictionary is a flat name/value dictionary. If a value is in the form
+  ${KEY} then the value is assumed to be the value of a transitive lookup on
+  KEY. If the value is in the form ${KEY:DEFAULT} then the value will be
+  DEFAULT if the KEY is not present.
+  """
+
   @property
   def default_value_interpreter(self):
+    """A function mapping a default value into its actual value.
+
+    When an expression specifies a default value, the default value is
+    specified as a string. However if the dictionary contains typed values
+    then it may wish to use this function to interpet the specified string
+    into a typed value.
+    """
     return self.__default_value_interpreter
 
   @default_value_interpreter.setter
-  def default_value_interpreter(self, f):
-    self.__default_value_interpreter = f
+  def default_value_interpreter(self, func):
+    """Binds the default_value_interpreter function.
+
+    Args:
+      func: [object (string)]: Function turning a string into an object.
+    """
+    self.__default_value_interpreter = func
 
   def __init__(self, *args, **kwargs):
-      super(ExpressionDict, self).__init__(*args, **kwargs)
-      self.__default_value_interpreter = lambda x: x
+    """Overrides standard dictionary constructor."""
+    super(ExpressionDict, self).__init__(*args, **kwargs)
+    self.__default_value_interpreter = lambda x: x
 
   def get(self, key, default_value=None):
-      if not key in self:
-          return default_value
-      return self.__resolve_value(key, saw=[], original=key)
+    """Implements dict interface.
+
+    This will track down values that reference other keys in the dictionary.
+    """
+    if not key in self:
+      return default_value
+    return self.__resolve_value(key, saw=[], original=key)
 
   def __getitem__(self, key):
-      if not key in self:
-          raise KeyError(key)
-      return self.__resolve_value(key, saw=[], original=key)
+    """Implements dict interface.
 
-  def __resolve_value(self, field, saw, original):
-    value = super(ExpressionDict, self).get(field, None)
-    if value is None and not field in self:
-      raise KeyError(field)
+    This will track down values that reference other keys in the dictionary.
+    """
+    if not key in self:
+      raise KeyError(key)
+    return self.__resolve_value(key, saw=[], original=key)
+
+  def __resolve_value(self, key, saw, original):
+    """Looks up specified key and returns its final value.
+
+    Args:
+      key: [string] Specification of the key to retrieve.
+      saw: [list of string] The path of keys we're chasing down for the value.
+      original: [string] The original starting point of the |saw| path.
+
+    Raises:
+      KeyError if the |key| is not in the dictionary.
+      ValueError if a cycle is encountered.
+    """
+    value = super(ExpressionDict, self).get(key, None)
+    if value is None and not key in self:
+      raise KeyError(key)
 
     if not isinstance(value, basestring):
       return value
 
-    if field in saw:
+    if key in saw:
       raise ValueError('Cycle looking up variable ' + original)
-    saw = saw + [field]
+    saw = saw + [key]
 
-    expression_re = re.compile('\${([\._a-zA-Z0-9]+)(:.+?)?}')
+    expression_re = re.compile(r'\${([\._a-zA-Z0-9]+)(:.+?)?}')
     exact_match = expression_re.match(value)
     if exact_match and exact_match.group(0) == value:
       try:
@@ -70,16 +110,16 @@ class ExpressionDict(dict):
     # Look for fragments of ${key} or ${key:default} then resolve them.
     text = value
     for match in expression_re.finditer(text):
-        result.append(text[offset:match.start()])
-        try:
-          got = self.__resolve_value(match.group(1), saw, original)
-          result.append(str(got))
-        except KeyError:
-          if match.group(2):
-            result.append(str(match.group(2)[1:]))
-          else:
-            result.append(match.group(0))
-        offset = match.end()  # skip trailing '}'
+      result.append(text[offset:match.start()])
+      try:
+        got = self.__resolve_value(match.group(1), saw, original)
+        result.append(str(got))
+      except KeyError:
+        if match.group(2):
+          result.append(str(match.group(2)[1:]))
+        else:
+          result.append(match.group(0))
+      offset = match.end()  # skip trailing '}'
     result.append(text[offset:])
 
     return ''.join(result)

--- a/spinnaker/spinnaker_testing/kato.py
+++ b/spinnaker/spinnaker_testing/kato.py
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+# TODO(ewiseblatt): 20151125
+# This could probably become clouddriver.
+"""Specialization of SpinnakerAgent for interacting with Kato subsystem."""
+
+
 import json
 import spinnaker_testing.spinnaker as sk
 
@@ -65,13 +71,13 @@ class _KatoStatus(sk.SpinnakerStatus):
       pass
 
     if isinstance(doc, dict):
-      self._detail_path = doc['resourceUri']
-      self._request_id = doc['id']
+      self._bind_detail_path(doc['resourceUri'])
+      self._bind_id(doc['id'])
     else:
       self._error = 'Invalid response="{0}"'.format(original_response)
       self._finished = True
       self._failed = True
-      self._current_state = 'CITEST_INTERNAL_ERROR'
+      self.current_state = 'CITEST_INTERNAL_ERROR'
 
   def _update_response_from_json(self, doc):
     """Updates abstract SpinnakerStatus attributes from a Kato response.
@@ -79,9 +85,8 @@ class _KatoStatus(sk.SpinnakerStatus):
     This is called by the base class.
     """
     status = doc['status']
-    completed = status['completed']
     failed = status['failed']
-    self._current_state = status['phase']
+    self.current_state = status['phase']
     self._exception_details = None
     if status['completed']:
       self._finished = True
@@ -108,7 +113,7 @@ class KatoAgent(sk.SpinnakerAgent):
     Returns:
        JSON encoded payload string for Kato request.
     """
-    return KatoAgent.make_payload([{ name: payload_dict }])
+    return KatoAgent.make_payload([{name: payload_dict}])
 
   @staticmethod
   def make_payload(payload_dict_list):

--- a/spinnaker/spinnaker_testing/yaml_accumulator.py
+++ b/spinnaker/spinnaker_testing/yaml_accumulator.py
@@ -12,30 +12,59 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+"""Helper module for converting YAML into flat dictionaries."""
+
+
 import yaml
 
 
-def __flatten_into(root, prefix, result):
-  for name,value in root.items():
+def __flatten_into(root, prefix, target):
+  """Helper function that flattens a dictionary into the target dictionary.
+
+  Args:
+    root: [dict] The dictionary to flatten from.
+    prefix: [string] The key prefix to use when adding entries into the target.
+    target: [dict] The dictinoary to update into.
+  """
+  for name, value in root.items():
     key = prefix + name
     if isinstance(value, dict):
-      __flatten_into(value, key + '.', result)
+      __flatten_into(value, key + '.', target)
     else:
-      result[key] = value
+      target[key] = value
 
 
 def flatten(root):
+  """Flatten a hierarchical YAML dictionary into one with composite keys.
+
+  Args:
+    root: [dict] A hierarchical dictionary.
+
+  Returns:
+    Equivalent dictionary with '.'-delimited keys.
+  """
   result = {}
   __flatten_into(root, '', result)
   return result
 
 
-def load_string(source, d):
-  d.update(flatten(yaml.load(source, Loader=yaml.Loader)))
+def load_string(source, target):
+  """Load dictionary implied by YAML text into target dictionary.
+
+  Args:
+    source: [string] YAML document text.
+    target: [dict] To update from YAML.
+  """
+  target.update(flatten(yaml.load(source, Loader=yaml.Loader)))
 
 
-def load_path(path, d):
+def load_path(path, target):
+  """Load dictionary implied by YAML file into target dictionary.
+
+  Args:
+    path: [string] Path to file containing YAML document text.
+    target: [dict] To update from YAML.
+  """
   with open(path, 'r') as f:
-    d.update(flatten(yaml.load(f, Loader=yaml.Loader)))
+    target.update(flatten(yaml.load(f, Loader=yaml.Loader)))
 


### PR DESCRIPTION
@lwander 
The only functionality change is that ExpressionDict conforms to the dict
interface, so get() no longer throws a KeyError (but **getitem** does).

I didnt change functionality but I did rename some variables/attributes/methods
 and wrapped some attributes as properties. Those are all only naming changes.

I'd like to do a bit more structural refactoring but saving it for a
different CL.
