### PR TITLE
Added snapshot and journal packages to start replacing Scribes.

### DIFF
--- a/citest/base/__init__.py
+++ b/citest/base/__init__.py
@@ -13,6 +13,18 @@
 # limitations under the License.
 
 
+from snapshot import (
+    JsonSnapshotable,
+    JsonSnapshotHelper,
+    JsonSnapshot,
+    Edge,
+    SnapshotEntity)
+
+from journal import Journal
+
+# DEPRECATED(ewiseblatt): 20151214
+# Scribes are deprecated by snapshoting and journaling
+# however these are not yet integrated.
 from scribe import(
     Doodle,
     Scribable,
@@ -22,6 +34,10 @@ from scribe import(
     DEFAULT_SCRIBE_REGISTRY,
     DETAIL_SCRIBE_REGISTRY)
 
+# DEPRECATED(ewiseblatt): 20151214
+# Scribes are deprecated by snapshoting and journaling
+# however these are not yet integrated, nor is there an HTML converter
+# for journals yet.
 from html_scribe import(
     HTML_SCRIBE_REGISTRY,
     HtmlScribe)

--- a/citest/base/journal.py
+++ b/citest/base/journal.py
@@ -1,0 +1,157 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Implements a Journal for managing JSON snapshots to a file.
+
+The JSON snspahosts in a journal are JsonSnashot. A journal is a collection
+of snapshots and, in future, other events.
+"""
+
+import json
+import threading
+import time
+
+from .snapshot import JsonSnapshot
+
+
+class Journal(object):
+  """Stores object snapshots into an output file.
+
+  The output file will contain a JSON document containing all the journal
+  entries. This document is a JSON list that is begun when the journal
+  is constructed, and ends when the terminate() method is called. If the
+  terminate is never called, then the document will be illformed, lacking
+  a list terminator.
+
+  The journal is thread-safe so multiple threads can write into it
+  concurrently.
+  """
+
+  def __init__(self, now_function=time.time):
+    """Constructs new journal.
+
+    Args:
+      now_function: [time] Optional override for timestamping function.
+          Returns a real value indicating the current time.
+    """
+    self.__encoder = json.JSONEncoder(indent=2, separators=(',', ': '))
+    self.__lock = threading.Lock()
+    self.__sep = ''
+    self.__now_function = now_function
+    self.__output = None
+
+  def now(self):
+    """Returns current timestamp for marking journal entries."""
+    return self.__now_function()
+
+  def open_with_path(self, _path, **metadata):
+    """Start a new journal file at the given path.
+
+    Args:
+      _path: [string] Path to file to write into.
+      metadata: [kwargs] Metadata for initial entry.
+    """
+    self.open_with_file(open(_path, 'r'), **metadata)
+
+  def open_with_file(self, _output, **metadata):
+    """
+    Args:
+      output: [FileObject] Takes ownership of the file to store snapshots into.
+      metadata: [kwargs] Metadata for initial message.
+    """
+    self.__lock.acquire(True)
+    try:
+      if self.__output is not None:
+        raise ValueError('Journal is already open.')
+
+      self.__output = _output
+      self.__output.write('[')
+    finally:
+      self.__lock.release()
+
+    self.write_message('Starting journal.', **metadata)
+
+  def terminate(self, **metadata):
+    """Stops writing into journal.
+
+    Args:
+      metadata: [kwargs]  Defines final metadata entry summarizing the journal.
+    """
+    self.write_message('Finished journal.', **metadata)
+    self.__lock.acquire(True)
+    try:
+      if self.__output is None:
+        raise ValueError('Journal is already terminated.')
+      self.__output.write(']')
+      self._do_close()
+      self.__output = None
+    finally:
+      self.__lock.release()
+
+  def write_message(self, _text, **metadata):
+    """Write a message into the journal.
+
+    Args:
+      _text: [string] The message text to write.
+      metadata: [kwargs] Additional metadata for the entry.
+    """
+    if not isinstance(_text, basestring) and _text is not None:
+      raise TypeError('{0} is not basestring'.format(_text.__class__))
+
+    entry = {
+        '_type': 'JournalMessage',
+        '_value': _text,
+    }
+    entry.update(metadata)
+    self.__write_json_object(entry)
+
+  def store(self, obj):
+    """Stores an object as a graph within the journal.
+
+    obj: [JsonSnapshotable] The object to store into the journal.
+    """
+    snapshot = JsonSnapshot()
+    snapshot.add_data(obj)
+    self.__write_json_object(snapshot.to_json_object())
+
+  def _do_close(self):
+    """Actually closes the journal output file.
+
+    This is a hook for testing before we lose the output file.
+    """
+    self.__output.close()
+
+  def __write_json_object(self, json_object):
+    """Write JSON object into the journal file.
+
+    Args:
+      json_object: [any] Encodable object to store into the snapshot
+    """
+
+    json_copy = dict(json_object)
+    json_copy.setdefault('_timestamp', self.now())
+
+    # protect both the encoder and the output stream.
+    self.__lock.acquire(True)
+    try:
+      if self.__output is None:
+        raise ValueError('Journal is not open')
+
+      text = self.__encoder.encode(json_copy)
+      self.__output.write(self.__sep)
+      self.__output.write(text)
+      self.__sep = ',\n'
+    finally:
+      self.__lock.release()

--- a/citest/base/snapshot.py
+++ b/citest/base/snapshot.py
@@ -1,0 +1,711 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Implements a graph representing data model state at a point in time.
+
+The graph is called a "JsonSnapshot" (snapshot) to reflect fact that it is a
+point in time and represented using JSON. A snapshot consists of data objects
+(entities) that have relationships (edges) to one another. Entities and edges
+can be annotated using arbitrary sets of name/value metatdata.
+
+The Snpashot, Entities, and Edges are all specific to snapshots and expressing
+the data model as opposed to implementing the data model. An interface,
+"JsonSnapshotable" is used to import actual data model implementations into
+a snapshot. Adding this interface to a class and implementing its
+"export_to_json_snapshot()" method allows a runtime data model implementation
+to be captured as a SnapshotEntity within a JsonSnapshot defined here.
+
+It is important that this is a snapshot because we want to capture how values
+change over time. Simply modeling the relationship among data without the
+current values would miss the distinction of what the actual values were at
+different points in time.
+
+Snapshots support a meta-model where relationships can be specified using
+the following names and concepts:
+  INPUT: The value is used as input. Input is used to create a work product,
+     and the value may change from time to time.
+  OUTPUT: The value is the result of a work product.
+  DATA: The value is a data value, usually input or output, but may differ
+     depending on your perspective but is usually clear from the context.
+     This is intended for generic entities that are building blocks for
+     different contexts, sometimes input and sometimes output.
+  ERROR: The value denotes an error. Errors are different from INVALID,
+     in that an error typically indicates a failure to perform or complete
+     the operation, where as an INVALID result indicates that the operation
+     completed but did not perform as expected.
+  MECHANISM: The value describes a mechanism used to perform or assist in
+     the creation or evaluation of a work product.
+  CONTROL: The value is used as a configuration parameter. This is different
+     from an INPUT though may not always be clear exactly which to use.
+     Controls are usually consumed by mechanisms whereas inputs are consumed
+     by operations.
+  VALID: The value denotes an expected or desirable result. This usually
+     subsumes an output but draws attention to the significance of it being
+     of interest from a testing perspective.
+  INVALID: The value denotes an unexpected or undesirable result. This usually
+     subsumes an output but draws attention to the significance of it being
+     of interest from a testing perspective.
+"""
+
+import json
+
+
+def _normalize_metadata_value(value):
+  """Convert value into an appropriate format to use as metadata.
+
+  Args:
+    value: [obj] A value of a primitive type.
+
+  Returns:
+    The encoding of value to use as a metadata value.
+  """
+  if isinstance(value, (basestring, bool, int, long, float, None.__class__)):
+    return value
+  if isinstance(value, type):
+    return 'type ' + value.__name__
+  raise TypeError('{0} is not a valid metadata type: {1}'.format(
+      value.__class__, value))
+
+
+def _normalize_metadata_kwargs(metadata):
+  """Convert metadata dictionary into an appropriate format for use as metadata.
+
+  Args:
+    metadata: [dict] The dictionary of metadata values.
+
+  Returns:
+    A dictionary of appropriately encoded values.
+  """
+  result = {}
+  for key, value in metadata.items():
+    result[key] = _normalize_metadata_value(value)
+  return result
+
+
+class JsonSnapshotable(object):
+  """Interface for storing an object into a JsonSnapshot."""
+
+  # pylint: disable=too-few-public-methods
+  def export_to_json_snapshot(self, snapshot, entity):
+    """Store this object state into the snapshot.
+
+    The stored state can reference other objects already in the snapshot,
+    or add multiple objects, and reference (or not) among them.
+
+    Args:
+      snapshot: [JsonSnapshot] The snapshot owning the entity is used to
+          relate to other entities.
+      entity: [SnapshotEntity] The snapshot entity to export into.
+    """
+    raise NotImplementedError('{0}.export_to_json_snapshot'.format(
+        self.__class__))
+
+
+class Edge(object):
+  """Represents a relationship between entities (an edge in the a graph).
+
+  Edges are annotated relationships to values. A value is either a
+  SnapshotEntity (which links to another first class node in the graph)
+  or a primitive value, which is annotated using a reserved "_value" annotation
+  on the edge itself.
+
+  Edges are intended to be directional and unique. However, two entities can
+  share multiple edges between them where each edge represents a distincly
+  different relationship. The source endpoint is implicit and later associated
+  with the entity that "has" the relationship. The target endpoint is bound
+  to the edge (or the _value annotation). Reserved annotations have leading
+  underscores in their names.
+
+  Standard annotations on an edge include:
+     _to: [int] If present then this edge references another entity.
+        The referenced entity has the |_id| matching the edge's |_to|.
+     _value: [any] If present then this edge references a  value
+        that is an implied entity specifying this value.
+     label: The name of the relationship for display purposes.
+     relation: The type of relationship
+  """
+
+  @property
+  def metadata(self):
+    """Metadata annotations on the edge.
+
+    The metadata dictionary on the node should not be modified directly.
+    Instead use add_metadata() to add additional annotations.
+    """
+    return self.__metadata
+
+  @property
+  def target(self):
+    """Returns the target node, if any."""
+    return self.__target
+
+  @property
+  def value(self):
+    """Returns the value."""
+    return self.__value
+
+  def __init__(self, _to_json_object, _target=None, _value=None, **metadata):
+    """Constructs the edge.
+
+    Args:
+      _to_json_object: [obj (Edge)] Converts edge to json object to serialize.
+      _target: [SnapshotEntity] The target entity, or None.
+      _value: [SnapshotEntity] The edge value, or None if same as _target.
+      metadata: [kwargs] Additional metadata annotations for the edge.
+         The keys are determined by the Entity at the source of the edge.
+    """
+    self.__metadata = _normalize_metadata_kwargs(metadata)
+    self.__to_json_object = _to_json_object
+    if _target is not None and not isinstance(_target, SnapshotEntity):
+      raise TypeError('{0} is not SnapshotEntity'.format(_target.__class__))
+    self.__target = _target
+    self.__value = _value if _value is not None else _target
+
+  def __str__(self):
+    return '  edge to {0} /{1}'.format(self.__target, self.metadata)
+
+  def add_metadata(self, key, value):
+    """Adds a new metadata key.
+
+    Args:
+      key: [string] Keys beginning with '_' are reserved for internal use.
+      value: [any] The metadata value.
+    """
+    value = _normalize_metadata_value(value)
+    self.__metadata[key] = value
+
+  def to_json_object(self):
+    """Returns a json object for this edge."""
+    return self.__to_json_object(self)
+
+
+class SnapshotEntity(object):
+  """Represents an entity in a snapshot.
+
+  An entity is a container with an id and metadata that references an
+  object snapshot value.
+
+  Entities are intended to be created by JsonSnapshots. Their id is an
+  opaque key   allocated by the snapshot creating the entity.
+
+  Metadata is a key/value dictionary where the keys are defined by the
+  Snapshot containing the entities.
+
+  Standard annotations include:
+     _type:  [string] The type of element within the snapshoting/journaling
+        system. Consider this the container,
+
+     _timestamp: [float] The time that the data was recorded.
+     _id: [int] The entities identifier used for references.
+     _edges: [list of dict] The list of edges from the entity.
+        This can be thought of as the entities properties.
+        All the other attributes are metadata.
+     _default_relation [string]: A default relationship that one should
+        assume inbound edges have if they do not explicitly specify one.
+        This is currently mostly used for entities that are members of
+        lists where the list has no way to specify individual elements.
+     class: The class of the original instance that this entity represents.
+  """
+
+  @property
+  def id(self):
+    """Returns the entity's id."""
+    # pylint: disable=invalid-name
+    return self.__id
+
+  @property
+  def metadata(self):
+    """Returns the entity metadata.
+
+    This is not intended to be modified directly, instead use add_metadata()
+    """
+    return self.__metadata
+
+  @property
+  def edges(self):
+    """Returns all the edges originating from this entity."""
+    return self.__ordered_edges
+
+  @property
+  def edge_lists(self):
+    """Returns a list of edge lists from this entity to other entities.
+
+    Each list contains all the edges to a different target entity.
+    """
+    return self.__entity_edges.values()
+
+  def __init__(self, entity_id, **metadata):
+    """Constructs an entity.
+
+    Args:
+      entity_id: [id]  Determined by the Snapshot containing it.
+      metadata: [kwargs] Additional metadata can be provided. They keys are
+         determined by the Snapshot but not checked here.
+    """
+    self.__id = entity_id
+    self.__metadata = _normalize_metadata_kwargs(metadata)
+    self.__ordered_edges = []
+    self.__entity_edges = {}  # subset that reference entities
+    self.__value_edges = []   # subset that reference values
+
+  def add_metadata(self, key, value):
+    """Adds a new metadata key.
+
+    Args:
+      key: [string] Keys beginning with '_' are reserved for internal use.
+      value: [any] The metadata value.
+    """
+    value = _normalize_metadata_value(value)
+    self.__metadata[key] = value
+
+  def add_edge(self, edge):
+    """Adds an edge that has already been constructed.
+
+    This method is typically called from JsonSnapshotEdgeBuilder, which
+    creates the edge being added here. This is because the edge typically
+    needs the snapshot to reference other entities, and the entity does not
+    typically have access to that.
+
+    We could add another helper method here, make_edge that essentially
+    fronts snapshot.edge_builder.make() but it isnt clear there is a point
+    to doing that other than increasing the surface area of API.
+
+    Args:
+      edge: [Edge] The existing edge instance to add.
+    """
+    if not isinstance(edge, Edge):
+      raise TypeError('{0} is not an Edge'.format(edge.__class__))
+
+    target = edge.target
+    if target is not None:
+      to_id = edge.target.id
+      if not to_id in self.__entity_edges:
+        self.__entity_edges[to_id] = [edge]
+      else:
+        self.__entity_edges[to_id].append(edge)
+    else:
+      self.__value_edges.append(edge)
+    self.__ordered_edges.append(edge)
+    return edge
+
+  def to_json_object(self):
+    """Returns entity as a dictionary that is json encodable."""
+    result = {'_id': self.__id}
+
+    edges = []
+    for edge in self.edges:
+      edges.append(edge.to_json_object())
+    if edges:
+      result['_edges'] = edges
+
+    result.update(self.__metadata)
+    return result
+
+
+class JsonSnapshotHelper(object):
+  """Helper class for implementing JsonSnapshotable."""
+
+  # pylint: disable=too-few-public-methods
+  @classmethod
+  def ToJsonSnapshotValue(cls, value, snapshot):
+    """Convert value into snapshot equivalent.
+
+    For the most part, this is the identity if value is a primitive type.
+    However lists and dictionaries may reference other entities that need
+    to be snapshotted. For example references to other entities, or other
+    object types that need to be converted.
+    """
+    # pylint: disable=invalid-name
+    # pylint: disable=unused-argument
+    if isinstance(value, (basestring, bool, int, long, float, None.__class__)):
+      return value
+
+    if isinstance(value, JsonSnapshotable):
+      # Turn value into an entity within the snapshot,
+      # and continue the method as if we got the entity.
+      value = snapshot.make_entity_for_data(value)
+
+    if isinstance(value, SnapshotEntity):
+      return {'_type': 'EntityReference', '_id': value.id}
+
+    if isinstance(value, list):
+      return [cls.ToJsonSnapshotValue(elem, snapshot) for elem in value]
+
+    if isinstance(value, dict):
+      result = {}
+      for name, elem in value.items():
+        result[name] = cls.ToJsonSnapshotValue(elem, snapshot)
+      return result
+
+    if isinstance(value, type):
+      return 'type ' + value.__name__
+
+    if isinstance(value, Exception):
+      return '{0}: {1}'.format(value.__class__.__name__, value)
+
+    raise TypeError(
+        '{0} is not implicitly JsonSnapshotable.'.format(value.__class__))
+
+  @staticmethod
+  def AssertExpectedValue(expect, have, msg=None):
+    """Verify that two values produce the same representation in a snapshot.
+
+    This is to support testing so that we can test equivalence of objects
+    within our data model and report the details on error.
+
+    Args:
+      expect: [any] The python value we expect.
+      have:   [any] The python value we have.
+      msg:    [string]  If provided, the message to raise on failure.
+
+    Raises:
+      AssertionError
+    """
+    # pylint: disable=invalid-name
+    if expect == have:
+      return
+
+    # The objects might still be equivalent.
+    # Snapshot each and compare the snapshots.
+    snapshot = JsonSnapshot()
+    expect_jsv = JsonSnapshotHelper.ToJsonSnapshotValue(expect, snapshot)
+    expect_so = snapshot.to_json_object()
+
+    snapshot = JsonSnapshot()
+    have_jsv = JsonSnapshotHelper.ToJsonSnapshotValue(have, snapshot)
+    have_so = snapshot.to_json_object()
+
+    if have_jsv == expect_jsv and have_so == expect_so:
+      return
+
+    if not msg:
+      expect_this = expect_so if isinstance(expect_jsv, dict) else expect_jsv
+      have_this = have_so if isinstance(have_jsv, dict) else have_jsv
+
+      # Display the json representations for detailed reporting.
+      encoder = json.JSONEncoder(indent=2, separators=(',', ': '))
+      expect_text = encoder.encode(expect_this)
+      have_text = encoder.encode(have_this)
+      msg = '\n--- EXPECT ---\n{0}\n--- GOT ---\n{1}\n---------'.format(
+          expect_text, have_text)
+    raise AssertionError(msg)
+
+  @staticmethod
+  def ValueToEncodedJson(value):
+    """Convert an object into its JSON-encoded JsonSnapshot equivalent.
+
+    This is to support testing.
+
+    Args:
+      value: [obj] The value we want to encode.
+    """
+    # pylint: disable=invalid-name
+
+    snapshot = JsonSnapshot()
+    value_obj = JsonSnapshotHelper.ToJsonSnapshotValue(value, snapshot)
+    snapshot_obj = snapshot.to_json_object()
+    json_obj = snapshot_obj if isinstance(value_obj, dict) else value_obj
+    return json.JSONEncoder(indent=2, separators=(',', ': ')).encode(json_obj)
+
+
+class JsonSnapshotEdgeBuilder(object):
+  """A helper class for relating data within a snapshot.
+
+  The methods in this class typically take a **metdata kwarg parameter
+  whose values will be annotations for the created edge. The positional
+  parameters have names starting with '_' to minimize the risk of having
+  name clashes between these internal parameters and arbitrary metadata
+  annotation keys.
+
+  This edge builder defines an meta-data model that is acting as a standard,
+  at least for the time being.
+  """
+
+  #pylint: disable=missing-docstring
+
+  def __init__(self, snapshot):
+    """Constructs builder.
+
+    Args:
+      snapshot: [JsonSnapshot] The snapshot holding the entities.
+    """
+    self.__snapshot = snapshot
+    self.__value_helper = JsonSnapshotHelper
+
+  def new_edge(self, _label, _value, **metadata):
+    """Creates a new edge to a target value.
+
+    This method creates a directional edge to the supplied value.
+    The edge will later be associated with an entity, giving it an
+    implicit initial endpoint.
+
+    Args:
+      _label: [string] The value of the 'label' metadata attribute.
+      _value: [obj] The value the edge is related to.
+         This can be either a SnapshotEntity, JsonSnapshotable value
+         contained by an entity, or primitive json value.
+      **metadata: [kwargs] Remaining metadata values.
+
+    Returns:
+      A snapshot edge.
+    """
+    if isinstance(_value, SnapshotEntity):
+      return self.__new_entity_edge(_value, label=_label, **metadata)
+
+    if isinstance(_value, JsonSnapshotable):
+      entity = self.__snapshot.make_entity_for_data(_value)
+      return self.__new_entity_edge(entity, label=_label, **metadata)
+
+    value = self.__value_helper.ToJsonSnapshotValue(_value, self.__snapshot)
+    return self.__new_value_edge(value, label=_label, **metadata)
+
+  @staticmethod
+  def  __new_entity_edge(_entity, **metadata):
+    def to_json_object(edge):
+      """Returns a json object for this edge."""
+      result = {}
+      result['_to'] = edge.target.id
+      result.update(edge.metadata)
+      return result
+    return Edge(_target=_entity, _to_json_object=to_json_object, **metadata)
+
+  @staticmethod
+  def  __new_value_edge(_value, **metadata):
+    def to_json_object(edge):
+      """Convert the edge into a dictionary that can be encoded as JSON."""
+      result = {}
+      if _value is not None:
+        result['_value'] = _value
+      if edge.metadata:
+        result.update(edge.metadata)
+      return result
+    return Edge(_value=_value, _to_json_object=to_json_object, **metadata)
+
+  def make(self, _from, _label, _value, **metadata):
+    """Creates a new directional edge from |_from| to |_value|.
+
+    The edge will be labeled with |_label| and annotated with |**metadata|
+    and added to |_from|.
+
+    Args:
+      _from: [SnapshotEntity] The entity to attach the edge source endpoint to.
+      _label: [string] The value of a 'label' annotation.
+      _value: [any] See new_edge().
+      metadata: [kwargs] Additional annotation for the edge.
+    """
+    return _from.add_edge(self.new_edge(_label, _value, **metadata))
+
+  def make_input(self, _from, _label, _value, **metadata):
+    return _from.add_edge(
+        self.new_edge(_label, _value, relation='INPUT', **metadata))
+
+  def make_output(self, _from, _label, _value, **metadata):
+    return _from.add_edge(
+        self.new_edge(_label, _value, relation='OUTPUT', **metadata))
+
+  def make_mechanism(self, _from, _label, _value, **metadata):
+    return _from.add_edge(
+        self.new_edge(_label, _value, relation='MECHANISM', **metadata))
+
+  def make_control(self, _from, _label, _value, **metadata):
+    return _from.add_edge(
+        self.new_edge(_label, _value, relation='CONTROL', **metadata))
+
+  def make_data(self, _from, _label, _value, **metadata):
+    return _from.add_edge(
+        self.new_edge(_label, _value, relation='DATA', **metadata))
+
+  def make_error(self, _from, _label, _value, **metadata):
+    return _from.add_edge(
+        self.new_edge(_label, _value, relation='ERROR', **metadata))
+
+  def make_valid(self, _from, _label, _value, **metadata):
+    return _from.add_edge(
+        self.new_edge(_label, _value, relation='VALID', **metadata))
+
+  def make_invalid(self, _from, _label, _value, **metadata):
+    return _from.add_edge(
+        self.new_edge(_label, _value, relation='INVALID', **metadata))
+
+  @staticmethod
+  def object_count_to_summary(obj, subject='object', plural=None):
+    """A helper method for returning a string indicating a cardinality.
+
+    Args:
+      obj: [dict, or list] The object whose cardinality we are interested in.
+      subject: [string] The singular name of the entities we are counting.
+      plural: [string] The plural name of entities we are counting.
+         None indicates just add an 's'.
+    Returns:
+      A string summarizing how many things we have.
+    """
+    count = 0 if not obj else len(obj)
+    if count == 1:
+      return '1 ' + subject
+
+    if plural is None:
+      plural = subject + 's'
+    return '{count} {plural}'.format(count=count, plural=plural)
+
+  @staticmethod
+  def determine_valid_relation(is_valid):
+    """Return specific relation name depending on validity of the value."""
+    return 'VALID' if is_valid else 'INVALID'
+
+
+class JsonSnapshot(object):
+  """Represents a snapshot of a data model relating entities to one another.
+
+  A snapshot is a list of entities, each of which can have arbitrary
+  relationships to values. Values are either primitive types or other
+  entities.
+
+  Relationships are edges that connect entities to values. These edges can
+  be further annotated with other attributes describing the relationship.
+  The interpretation of these annotations is generally not defined by this
+  module, but can be defined by the entities themselves.
+
+  Primitive values are stored as metadata on the edge itself for brevity.
+  By convention, internal (standard) annotations have a leading '_', and
+  those left to the "user domain" do not.
+
+  Entities (and snapshots) are also annotated. All these objects are
+  stored (in json) using dictionaries. There is no explicit distinction
+  in the JSON between metadata and the objects representation.
+
+  Standard annotations include:
+     _subject_id: [int] The "main" entity being snapshotted.
+         This is currently a hack, assuming that a snapshot is of a
+         particular object. Really the subject are all the roots but
+         this requires work to figure out so isnt easily inspectable.
+     _title: [string] The title for the snapshot, if any.
+     _entities: [dict of Entity] This is a map of entities keyed by
+         their _id. Note that JSON forces these keys to be strings
+         but we're currently storing the attributes as integers.
+         So to perform a lookup in this dictionary, you will need to
+         convert the integer keys into strings.
+  """
+
+  @property
+  def metadata(self):
+    """Metadata annotations on the snapshot.
+
+    The metadata should not be modified directly.  Instead use add_metadata().
+    """
+    return self.__metadata
+
+  @property
+  def edge_builder(self):
+    """Facilitate associating relations among data within the snapshot."""
+    return self.__edge_builder
+
+  def __init__(self, **metadata):
+    """Constructs snapshot.
+
+    Args:
+      metadata: [kwargs] Metadata to associate with the snapshot.
+    """
+    self.__last_id = 0
+    self.__entities = {}
+    self.__snapshotable_entities = {}
+    self.__metadata = _normalize_metadata_kwargs(metadata)
+    self.__subject_entity = None
+    self.__edge_builder = JsonSnapshotEdgeBuilder(self)
+
+  def add_metadata(self, key, value):
+    """Adds a new metadata key.
+
+    Args:
+      key: [string] Keys beginning with '_' are reserved for internal use.
+      value: [any] The metadata value.
+    """
+    value = _normalize_metadata_value(value)
+    self.__metadata[key] = value
+
+  def add_data(self, snapshotable):
+    """Adds snapshotable data into the snapshot.
+
+    Args:
+      snapshotable: [JsonSnapshotable] Data to add to snapshot.
+    """
+    self.make_entity_for_data(snapshotable)
+
+  def make_entity_for_data(self, snapshotable):
+    """Returns a possibly shared node for |snapshotable|.
+
+    Args:
+      snapshotable: [JsonSnapshotable] Data for a unique entity. The
+        entity may already exist with |snapshotable| (as opposed to an
+        existing node for different snapshotable).
+    """
+    if not isinstance(snapshotable, JsonSnapshotable):
+      raise TypeError(
+          '{0} is not JsonSnapshotable'.format(snapshotable.__class__))
+    entity = self.find_entity_for_data(snapshotable)
+    if entity is None:
+      entity = self.new_entity()
+      entity.add_metadata('class', snapshotable.__class__)
+      self.__snapshotable_entities[id(snapshotable)] = entity
+      snapshotable.export_to_json_snapshot(self, entity)
+    return entity
+
+  def new_entity(self, **metadata):
+    """Returns a new entity.
+
+    Args:
+      metadata: [kwargs] Metadata to bind to the node.
+      """
+    self.__last_id += 1
+    entity = SnapshotEntity(entity_id=self.__last_id, **metadata)
+    self.__entities[self.__last_id] = entity
+    if self.__subject_entity is None:
+      self.__subject_entity = entity
+    return entity
+
+  def find_entity_for_data(self, snapshotable):
+    """Find a entity containing data, if any.
+
+    Args:
+      snapshotable: [JsonSnapshotable] The data bound to the entity.
+
+    Returns:
+      None if no entity contains |snapshotable|.
+    """
+    return self.__snapshotable_entities.get(id(snapshotable))
+
+  def get_entity(self, entity_id):
+    """Looks up the entity with the given entity_id.
+
+    Args:
+      entity_id: [any]  The id comes from previously allocated entity.
+
+    Raises:
+      KeyError if the entity_id was not known.
+    """
+    return self.__entities[entity_id]
+
+  def to_json_object(self):
+    """Returns snapshot as a dictionary that is json encodable."""
+    result = {'_type': 'JsonSnapshot'}
+    if self.__entities:
+      result['_subject_id'] = self.__subject_entity.id
+      entities = {}
+      for key, entity in self.__entities.items():
+        entities[key] = entity.to_json_object()
+      result['_entities'] = entities
+
+    if self.__metadata:
+      result.update(self.__metadata)
+    return result

--- a/tests/base/journal_test.py
+++ b/tests/base/journal_test.py
@@ -1,0 +1,202 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Test journal module."""
+# pylint: disable=missing-docstring
+# pylint: disable=too-few-public-methods
+# pylint: disable=invalid-name
+
+
+import json
+import unittest
+from StringIO import StringIO
+from citest.base import Journal
+from citest.base import (JsonSnapshot, JsonSnapshotable)
+
+
+class TestDetails(JsonSnapshotable):
+  def export_to_json_snapshot(self, snapshot, entity):
+    snapshot.edge_builder.make(entity, 'DetailR', 3.14)
+    snapshot.edge_builder.make(entity, 'DetailB', True)
+
+
+class TestData(JsonSnapshotable):
+  def __init__(self, name, param, data=None):
+    self.__name = name
+    self.__param = param
+    self.__data = data
+
+  def export_to_json_snapshot(self, snapshot, entity):
+    entity.add_metadata('name', self.__name)
+    entity.add_metadata('param', self.__param)
+
+    if self.__data:
+      data = snapshot.make_entity_for_data(self.__data)
+      snapshot.edge_builder.make(entity, 'Data', data)
+    return entity
+
+
+class TestClock(object):
+  _BASE_TIME = 100.123
+  @property
+  def last_time(self):
+    return self.next_time - 1
+
+  @property
+  def elapsed_time(self):
+    return self.next_time - TestClock._BASE_TIME
+
+  def __init__(self):
+    self.next_time = TestClock._BASE_TIME
+
+  def __call__(self):
+    self.next_time += 1
+    return self.last_time
+
+
+class TestJournal(Journal):
+  @property
+  def clock(self):
+    return self.__clock
+
+  def __init__(self, output):
+    self.__clock = TestClock()
+    super(TestJournal, self).__init__(now_function=self.__clock)
+    self.open_with_file(output)
+    self.__output = output
+    self.final_content = None
+
+  def _do_close(self):
+    self.final_content = self.__output.getvalue()
+    super(TestJournal, self)._do_close()
+
+
+class JournalTest(unittest.TestCase):
+  @staticmethod
+  def expect_message_text(_clock, _text, metadata_dict=None):
+    entry = {
+        '_type': 'JournalMessage',
+        '_value': _text,
+        '_timestamp': _clock.last_time
+    }
+    if metadata_dict:
+      entry.update(metadata_dict)
+    return json.JSONEncoder(indent=2, separators=(',', ': ')).encode(entry)
+
+  def test_empty(self):
+    """Verify the journal starts end ends with the correct JSON text."""
+
+    output = StringIO()
+    journal = TestJournal(output)
+    initial_json_text = self.expect_message_text(journal.clock,
+                                                 'Starting journal.')
+    self.assertEquals('[{0}'.format(initial_json_text),
+                      output.getvalue())
+
+    journal.terminate()
+    final_json_text = self.expect_message_text(journal.clock,
+                                               'Finished journal.')
+    self.assertEquals('[{0},\n{1}]'.format(initial_json_text, final_json_text),
+                      journal.final_content)
+
+  def test_write_plain_message(self):
+    """Verify the journal contains messages we write into it."""
+    output = StringIO()
+    journal = TestJournal(output)
+    initial_json_text = self.expect_message_text(journal.clock,
+                                                 'Starting journal.')
+    self.assertEquals('[{0}'.format(initial_json_text),
+                      output.getvalue())
+
+    offset = len(output.getvalue())
+    journal.write_message('A simple message.')
+    message_json_text = self.expect_message_text(journal.clock,
+                                                 'A simple message.')
+    self.assertEquals(',\n' + message_json_text, output.getvalue()[offset:])
+
+    offset = len(output.getvalue())
+    journal.terminate()
+    final_json_text = self.expect_message_text(journal.clock,
+                                               'Finished journal.')
+    self.assertEquals(',\n' + final_json_text,
+                      journal.final_content[offset:-1])
+
+  def test_write_message_with_metadata(self):
+    """Verify the journal messages contain the metadata we add."""
+    output = StringIO()
+    journal = TestJournal(output)
+    offset = len(output.getvalue())
+
+    journal.write_message('My message.', str='ABC', num=123)
+    metadata = {'str': 'ABC', 'num': 123}
+    message_json_text = self.expect_message_text(
+        journal.clock, 'My message.', metadata)
+
+    decoder = json.JSONDecoder(encoding='ASCII')
+    self.assertItemsEqual(decoder.decode(message_json_text),
+                          decoder.decode(output.getvalue()[offset + 2:]))
+
+  def test_store(self):
+    """Verify we store objects as JSON snapshots."""
+    data = TestData('NAME', 1234, TestDetails())
+    decoder = json.JSONDecoder(encoding='ASCII')
+    snapshot = JsonSnapshot()
+    snapshot.add_data(data)
+
+    time_function = lambda: 1.23
+    journal = Journal(time_function)
+    output = StringIO()
+    journal.open_with_file(output)
+    offset = len(output.getvalue())
+
+    journal.store(data)
+    contents = output.getvalue()
+    got = decoder.decode(contents[offset + 2:])  # skip ',\n'
+    json_object = snapshot.to_json_object()
+    json_object['_timestamp'] = time_function()
+    self.assertItemsEqual(json_object, got)
+
+  def test_lifecycle(self):
+    """Verify we store multiple objects as a list of snapshots."""
+    first = TestData('first', 1, TestDetails())
+    second = TestData('second', 2)
+
+    journal = TestJournal(StringIO())
+
+    journal.store(first)
+    journal.store(second)
+    journal.terminate()
+
+    decoder = json.JSONDecoder(encoding='ASCII')
+    got = decoder.decode(journal.final_content)
+    self.assertEquals(4, len(got))
+
+    snapshot = JsonSnapshot()
+    snapshot.add_data(first)
+    json_object = snapshot.to_json_object()
+    json_object['_timestamp'] = journal.clock.last_time - 1
+    self.assertItemsEqual(json_object, got[1])
+
+    snapshot = JsonSnapshot()
+    snapshot.add_data(second)
+    json_object = snapshot.to_json_object()
+    json_object['_timestamp'] = journal.clock.last_time
+    self.assertItemsEqual(json_object, got[2])
+
+
+if __name__ == '__main__':
+  loader = unittest.TestLoader()
+  suite = loader.loadTestsFromTestCase(JournalTest)
+  unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/base/snapshot_test.py
+++ b/tests/base/snapshot_test.py
@@ -1,0 +1,207 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Test snapshot module."""
+# pylint: disable=missing-docstring
+# pylint: disable=too-few-public-methods
+# pylint: disable=invalid-name
+
+import unittest
+
+from citest.base import (JsonSnapshot, JsonSnapshotable, JsonSnapshotHelper)
+
+
+class TestLinkedList(JsonSnapshotable):
+  def __init__(self, name, next_elem=None):
+    self.__name = name
+    self.next = next_elem
+
+  def export_to_json_snapshot(self, snapshot, entity):
+    entity.add_metadata('name', self.__name)
+    if self.next:
+      next_target = snapshot.make_entity_for_data(self.next)
+      snapshot.edge_builder.make(entity, 'Next', next_target)
+
+
+class SnapshotTest(unittest.TestCase):
+  def test_assert_expected_value_ok(self):
+    tests = [
+        (False, False),
+        (1, 1),
+        ('a', 'a'),
+        (3.14, 3.14),
+        ([1, 'a'], [1, 'a']),
+        ({'a': 'A', 'b': 'B'}, {'b': 'B', 'a': 'A'}),
+        (TestLinkedList('A', TestLinkedList('B')),
+         TestLinkedList('A', TestLinkedList('B'))),
+        (None, None),
+        (dict.__class__, dict.__class__)]
+    for spec in tests:
+      JsonSnapshotHelper.AssertExpectedValue(spec[0], spec[1])
+
+    tests = [
+        (False, True),
+        (1, 2),
+        ('a', 'b'),
+        (3.14, -3.14),
+        ([1, 'a'], ['a', 1]),
+        ([1, 'a'], [1, 'a', 2]),
+        ({'a': 'A', 'b': 'B'}, {'a': 'A', 'b': 'B', 'c': 'C'}),
+        (TestLinkedList('A', TestLinkedList('B')),
+         TestLinkedList('A', TestLinkedList('C'))),
+        (None, False),
+        (dict, dict.__class__)]
+    for spec in tests:
+      self.assertRaises(
+          AssertionError,
+          JsonSnapshotHelper.AssertExpectedValue, spec[0], spec[1])
+
+  def test_snapshot_make_entity(self):
+    """Test snapshotting JsonSnapshotable objects into entities."""
+    elem = TestLinkedList('Hello')
+    snapshot = JsonSnapshot()
+    entity = snapshot.make_entity_for_data(elem)
+    found = snapshot.find_entity_for_data(elem)
+    self.assertEquals(found, entity)
+    self.assertEquals(id(found), id(entity))
+    self.assertItemsEqual({'_subject_id': 1,
+                           '_type': 'JsonSnapshot',
+                           '_entities': [{'_id': 1, 'name': 'Hello'}]},
+                          snapshot.to_json_object())
+
+  def test_snapshot_make_transitive_entity(self):
+    """Test snapshotting compound entities."""
+    elem = TestLinkedList('First', next_elem=TestLinkedList('Second'))
+    snapshot = JsonSnapshot()
+    snapshot.make_entity_for_data(elem)
+    entity = snapshot.make_entity_for_data(elem.next)
+    found = snapshot.find_entity_for_data(elem.next)
+    self.assertEquals(found, entity)
+    self.assertEquals(id(found), id(entity))
+    self.assertItemsEqual({'_subject_id': 1,
+                           '_type': 'JsonSnapshot',
+                           '_entities': [{'_id': 1, 'name': 'First',
+                                          '_edges':[{'_to': 2}]},
+                                         {'_id': 2, 'name': 'Second'}]},
+                          snapshot.to_json_object())
+
+  def test_snapshot_full_entities(self):
+    """Test snapshotting an entity whose data are all entities."""
+    snapshot = JsonSnapshot(title='Test Graph')
+    entity_a = snapshot.new_entity(name='Entity Name')
+    expect_a = {'_id': 1, 'name': 'Entity Name'}
+
+    entity_b = snapshot.new_entity(data=1234, type='scalar')
+    expect_b = {'_id': 2, 'data': 1234, 'type': 'scalar'}
+
+    entity_c = snapshot.new_entity(data=3.14, type='real')
+    expect_c = {'_id': 3, 'data': 3.14, 'type': 'real'}
+
+    snapshot.edge_builder.make(entity_a, 'A to B', entity_b)
+    expect_ab = {'_to': entity_b.id, 'label': 'A to B'}
+
+    snapshot.edge_builder.make(entity_a, 'A to C', entity_c)
+    expect_ac = {'_to': entity_c.id, 'label': 'A to C'}
+
+    expect_a['_edges'] = [expect_ab, expect_ac]
+    expect = {'_subject_id': 1,
+              '_type': 'JsonSnapshot',
+              '_entities': [expect_a, expect_b, expect_c],
+              'title': 'Test Graph'}
+    json_obj = snapshot.to_json_object()
+    self.assertItemsEqual(expect, json_obj)
+
+  def test_snapshot_fields(self):
+    """Test snapshotting an entity whose data are simple values."""
+    snapshot = JsonSnapshot(title='Test Snapshot')
+    entity_a = snapshot.new_entity(name='Entity Name')
+    expect_a = {'_id': 1, 'name': 'Entity Name'}
+
+    expect_edges = []
+    snapshot.edge_builder.make(entity_a, 'scalar', 1234)
+    expect_edges.append({'_value': 1234, 'label': 'scalar'})
+
+    snapshot.edge_builder.make(entity_a, 'real', 3.14)
+    expect_edges.append({'_value': 3.14, 'label': 'real'})
+
+    expect = {'_subject_id': 1,
+              '_type': 'JsonSnapshot',
+              '_entities': [expect_a],
+              'title': 'Test Snapshot'}
+    json_obj = snapshot.to_json_object()
+
+    self.assertItemsEqual(expect, json_obj)
+
+  def test_snapshot_edge_builder(self):
+    """Test focused on snapshot.edge_builder property."""
+    snapshot = JsonSnapshot(title='Test Snapshot')
+    entity_a = snapshot.new_entity(name='Entity A')
+    entity_b = snapshot.new_entity(name='Entity B')
+    expect_a = {'_id': 1, 'name': 'Entity A'}
+
+    expect_edges = []
+    snapshot.edge_builder.make_mechanism(entity_a, 'B', entity_b)
+    expect_edges.append({'_to': 2, 'label': 'B', 'relation': 'MECHANISM'})
+
+    snapshot.edge_builder.make_control(entity_a, 'field', -321)
+    expect_edges.append({'_value': -321, 'label': 'field',
+                         'relation': 'CONTROL'})
+
+    expect = {'_subject_id': 1,
+              '_type': 'JsonSnapshot',
+              '_entities': [expect_a],
+              'title': 'Test Snapshot'}
+    json_obj = snapshot.to_json_object()
+
+    self.assertItemsEqual(expect, json_obj)
+
+  def test_snapshot_list(self):
+    a = TestLinkedList('A')
+    b = TestLinkedList('B')
+    c = TestLinkedList('C')
+    a.next = b
+    b.next = c
+
+    snapshot = JsonSnapshot()
+    self.assertIsNone(snapshot.find_entity_for_data(b))
+    self.assertIsNone(snapshot.find_entity_for_data(b)) # Still none
+    snapshot.add_data(a)
+    json_object = snapshot.to_json_object()
+
+    have_b = snapshot.find_entity_for_data(b)
+    self.assertEquals(2, have_b.id)
+    entity_b = snapshot.make_entity_for_data(b)
+    self.assertEquals(id(have_b), id(entity_b))
+
+    have_c = snapshot.find_entity_for_data(c)
+    entity_c = snapshot.make_entity_for_data(c)
+    self.assertEquals(id(have_c), id(entity_c))
+    self.assertEquals(3, entity_c.id)
+
+    expect = {
+        '_subject_id': 1,
+        '_type': 'JsonSnapshot',
+        '_entities': [
+            {'_id': 1, 'name': 'A', '_edges': [{'_to': 2}]},
+            {'_id': 2, 'name': 'B', '_edges': [{'_to': 3}]},
+            {'_id': 3, 'name': 'C'}]}
+
+    self.assertItemsEqual(expect, json_object)
+
+
+if __name__ == '__main__':
+  loader = unittest.TestLoader()
+  suite = loader.loadTestsFromTestCase(SnapshotTest)
+  unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
A snapshot captures the state and relationships of the data model at
a particular point in time. This is stored as graph of entities with
annotated edges among them. Where values are trivial, the values are
encoded into the edge itself as a _value annotation.

A journal is just a sequence of snapshots that can write to a file.
In the future, components will be added to render the journal into
a report to facilitate debugging or other reading.

This replaces scribes which tried to encode the report directly, but
that required anticiting up front what should be included in the report
and how it should be rendered, and the components often reference common
objects without being clear that these are the same references. While it
isnt clear yet how to render the JSON, the graphs should provide a more
expressive capture and can allow rendering to be performed later, perhaps
over multiple passes, with different viewpoints to support the task at hand.
And the journal can contain a more complete trace with all the details, letting
the post process reporting pick the level of abstraction and scope to
include in the report.

Whereas in practice scribes used a Scribable interface that took "parts",
and an optional specialized renderer, where each part contained a relation
to the thing it was a part of, the JsonSnapshot uses a "JsonSnapshotable"
interface were the object is given an entity to fill out and the snapshot
that contains the entity. The object can write its components into the snapshot
and build the annotated edges to them, using the snapshot as the data store
so that references to common entities can be shared within the graph. A helper
class within the snapshot for building edges keeps this to what I hope is
a similar ease for snapshoting a typical object.
