### PR TITLE
Use JsonSnapshot throughout the json_contract package and deprecate S…

### DIFF
--- a/citest/json_contract/binary_predicate.py
+++ b/citest/json_contract/binary_predicate.py
@@ -48,6 +48,11 @@ class BinaryPredicate(predicate.ValuePredicate):
             and self._name == op._name
             and self._operand == op._operand)
 
+  def export_to_json_snapshot(self, snapshot, entity):
+    """Implements JsonSnapshotable interface."""
+    snapshot.edge_builder.make(entity, 'Name', self._name)
+    snapshot.edge_builder.make_control(entity, 'Operand', self._operand)
+
   def _make_scribe_parts(self, scribe):
     # Do not inherit from the base class because it will add our string
     # value, which would be superfluous.
@@ -151,9 +156,9 @@ class DictSubsetPredicate(BinaryPredicate):
       # THEN ensure that |a_item| is a subset of |b_item|.
       if isinstance(b_value, list):
         elem_pred = (LIST_SUBSET
-                       if isinstance(a_value, list)
-                       else qp.UniversalOrExistentialPredicateFactory(
-                           False, CONTAINS))
+                        if isinstance(a_value, list)
+                        else qp.UniversalOrExistentialPredicateFactory(
+                            False, CONTAINS))
         result = elem_pred(a_value)(b_value)
         if not result:
           return result.clone_with_new_context(source, namepath)
@@ -229,8 +234,8 @@ class ListSubsetPredicate(_BaseListMembershipPredicate):
 
   def __init__(self, operand, strict=False):
     if not isinstance(operand, list):
-        raise TypeError(
-            '{0} is not a list: {1!r}'.format(operand.__class__, operand))
+      raise TypeError(
+          '{0} is not a list: {1!r}'.format(operand.__class__, operand))
     super(ListSubsetPredicate, self).__init__(
         'has-subset', operand, strict=strict)
 
@@ -430,9 +435,9 @@ LIST_EQ = StandardBinaryPredicateFactory(
 LIST_NE = StandardBinaryPredicateFactory(
     '!=', lambda a, b: a != b, operand_type=list)
 LIST_MEMBER = (lambda operand, strict=False:
-                 ListMembershipPredicate(operand, strict=strict))
+                  ListMembershipPredicate(operand, strict=strict))
 LIST_SUBSET = (lambda operand, strict=False:
-                 ListSubsetPredicate(operand, strict=strict))
+                  ListSubsetPredicate(operand, strict=strict))
 
 CONTAINS = ContainsPredicate
 EQUIVALENT = EquivalentPredicate

--- a/citest/json_contract/json_error.py
+++ b/citest/json_contract/json_error.py
@@ -14,10 +14,17 @@
 
 
 from ..base.scribe import Scribable
+from ..base import JsonSnapshotable
 
 
-class JsonError(ValueError, Scribable):
+class JsonError(ValueError, Scribable, JsonSnapshotable):
   """Denotes an error relatived to invalid JSON."""
+
+  def export_to_json_snapshot(self, snapshot, entity):
+    """Implements JsonSnapshotable interface."""
+    snapshot.edge_builder.new(entity, 'Message', self.message)
+    if self.__cause:
+      snapshot.edge_builder.make(entity, 'CausedBy', str(self.__cause))
 
   def _make_scribe_parts(self, scribe):
     parts = [scribe.build_part('Message', self.message)]

--- a/citest/json_contract/logic_predicate.py
+++ b/citest/json_contract/logic_predicate.py
@@ -36,6 +36,11 @@ class ConjunctivePredicate(predicate.ValuePredicate):
     return (self.__class__ == pred.__class__
             and self._conjunction == pred._conjunction)
 
+  def export_to_json_snapshot(self, snapshot, entity):
+    """Implements JsonSnapshotable interface."""
+    snapshot.edge_builder.make(entity, 'Conjunction', self._conjunction,
+                               join='AND')
+
   def _make_scribe_parts(self, scribe):
     parts = []
     for operand in self._conjunction:
@@ -78,6 +83,11 @@ class DisjunctivePredicate(predicate.ValuePredicate):
   def append(self, pred):
     self._disjunction.append(pred)
 
+  def export_to_json_snapshot(self, snapshot, entity):
+    """Implements JsonSnapshotable interface."""
+    snapshot.edge_builder.make(entity, 'Disjunction', self._disjunction,
+                               join='OR')
+
   def _make_scribe_parts(self, scribe):
     parts = []
     for operand in self._disjunction:
@@ -107,8 +117,8 @@ class NegationPredicate(predicate.ValuePredicate):
   def predicate(self):
     return self._pred
 
-  def __init__(self, predicate):
-    self._pred = predicate
+  def __init__(self, pred):
+    self._pred = pred
 
   def __str__(self):
     return 'NOT ({0})'.format(self._pred)
@@ -116,6 +126,10 @@ class NegationPredicate(predicate.ValuePredicate):
   def __eq__(self, other):
     return (self.__class__ == other.__class__
             and self._pred == other._pred)
+
+  def export_to_json_snapshot(self, snapshot, entity):
+    """Implements JsonSnapshotable interface."""
+    snapshot.edge_builder.make_mechanism(entity, 'Predicate', self._pred)
 
   def _make_scribe_parts(self, scribe):
     return [scribe.part_builder.build_mechanism_part('Predicate', self._pred)]
@@ -175,6 +189,11 @@ class ConditionalPredicate(predicate.ValuePredicate):
     return (self.__class__ == other.__class__
             and self._if_pred == other._if_pred
             and self._then_pred == other._then_pred)
+
+  def export_to_json_snapshot(self, snapshot, entity):
+    """Implements JsonSnapshotable interface."""
+    snapshot.edge_builder.make_mechanism(entity, 'If', self._if_pred)
+    snapshot.edge_builder.make_mechanism(entity, 'Then', self._then_pred)
 
   def _make_scribe_parts(self, scribe):
     return [scribe.part_builder.build_mechanism_part('If', self._if_pred),

--- a/citest/json_contract/map_predicate.py
+++ b/citest/json_contract/map_predicate.py
@@ -16,12 +16,13 @@
 import collections
 
 from ..base.scribe import Scribable
+from ..base import JsonSnapshotable
 from . import predicate
 
 
 class ObjectResultMapAttempt(
-      collections.namedtuple('ObjectResultMapAttempt', ['obj', 'result']),
-      Scribable):
+    collections.namedtuple('ObjectResultMapAttempt', ['obj', 'result']),
+    Scribable, JsonSnapshotable):
   @property
   def summary(self):
     return self.result.summary
@@ -34,13 +35,23 @@ class ObjectResultMapAttempt(
             and self.obj == attempt.obj
             and self.result == attempt.result)
 
+  def export_to_json_snapshot(self, snapshot, entity):
+    """Implements JsonSnapshotable interface."""
+    builder = snapshot.edge_builder
+    result_summary = '{name} {valid}'.format(
+        name=self.obj.__class__.__name__, valid=self.result.valid)
+    builder.make_input(entity, 'Mapped Object', self.obj, format='json')
+    builder.make(entity, 'Result', self.result,
+                 relation=builder.determine_valid_relation(self.result),
+                 summary=result_summary)
+
   def _make_scribe_parts(self, scribe):
     result_summary = '{name} {valid}'.format(
         name=self.obj.__class__.__name__, valid=self.result.valid)
     return [scribe.part_builder.build_input_part(
-               'Mapped Object', self.obj, summary=self.obj.__class__),
+                'Mapped Object', self.obj, summary=self.obj.__class__),
             scribe.part_builder.build_output_part(
-               'Result', self.result, summary=result_summary)]
+                'Result', self.result, summary=result_summary)]
 
 
 class MapPredicateResultBuilder(object):
@@ -83,6 +94,41 @@ class MapPredicateResult(predicate.CompositePredicateResult):
   @property
   def obj_list(self):
     return self._obj_list
+
+  @staticmethod
+  def __map_attempt_to_entity(attempt, snapshot):
+    attempt_entity = snapshot.new_entity()
+    attempt_entity.add_metadata('class', attempt.__class__)
+    builder = snapshot.edge_builder
+    builder.make_input(attempt_entity,'Object', attempt.obj,
+                       format='json',
+                       summary=attempt.obj.__class__)
+    builder.make(attempt_entity, 'Result Map', attempt.result,
+                 relation=builder.determine_valid_relation(attempt.result),
+                 summary=attempt.summary)
+    return attempt_entity
+
+  def export_to_json_snapshot(self, snapshot, entity):
+    """Implements JsonSnapshotable interface."""
+    fn = lambda l: [self.__map_attempt_to_entity(e, snapshot) for e in l]
+    builder = snapshot.edge_builder
+    builder.make_input(entity, 'Object List', self._obj_list,
+                       format='json',
+                       summary=builder.object_count_to_summary(
+                           self._obj_list, subject='mapped object'))
+    edge = builder.make(entity, 'Good Mappings',
+                        fn(self._good_map),
+                        summary=builder.object_count_to_summary(
+                            self._good_map, subject='valid mapping'))
+    if self._good_map:
+      edge.add_metadata('relation', 'VALID')
+    edge = builder.make(entity, 'Bad Mappings',
+                        fn(self._bad_map),
+                        summary=builder.object_count_to_summary(
+                            self._bad_map, subject='invalid mapping'))
+    if self._bad_map:
+      edge.add_metadata('relation', 'INVALID')
+    super(MapPredicateResult, self).export_to_json_snapshot(snapshot, entity)
 
   @staticmethod
   def _render_mapping(out, result_map_attempt):
@@ -168,7 +214,7 @@ class MapPredicate(predicate.ValuePredicate):
     Returns:
       MapPredicateResult of pred applied to all the objects.
     """
-    all_results  = []
+    all_results = []
     good_map = []
     bad_map = []
 
@@ -194,6 +240,14 @@ class MapPredicate(predicate.ValuePredicate):
         all_results=all_results,
         good_map=good_map,
         bad_map=bad_map)
+
+  def export_to_json_snapshot(self, snapshot, entity):
+    """Implements JsonSnapshotable interface."""
+    builder = snapshot.edge_builder
+    builder.make_mechanism(entity, 'Mapped Predicate', self._pred,
+                           summary=self._pred.__class__)
+    builder.make_control(entity, 'Min', self._min)
+    builder.make_control(entity, 'Max', self._max)
 
   def _make_scribe_parts(self, scribe):
     part_builder = scribe.part_builder

--- a/citest/json_contract/observation_failure.py
+++ b/citest/json_contract/observation_failure.py
@@ -26,6 +26,12 @@ class ObservationFailedError(predicate.PredicateResult):
     super(ObservationFailedError, self).__init__(valid)
     self._failures = failures
 
+  def export_to_json_snapshot(self, snapshot, entity):
+    """Implements JsonSnapshotable interface."""
+    super(ObservationFailedError, self).export_to_json_snapshot(
+        snapshot, entity)
+    snapshot.edge_builder.make(entity, 'Failures', self._failures)
+
   def _make_scribe_parts(self, scribe):
     inherited = super(ObservationFailedError, self)._make_scribe_parts(scribe)
     return [scribe.build_part('Failures', self._failures)] + inherited

--- a/citest/json_contract/path.py
+++ b/citest/json_contract/path.py
@@ -16,8 +16,10 @@
 """Track the accumulation of Path/Value pairs found."""
 
 import collections
+from ..base import JsonSnapshotable
 
-class PathValue(collections.namedtuple('PathValue', ['path', 'value'])):
+class PathValue(collections.namedtuple('PathValue', ['path', 'value']),
+                JsonSnapshotable):
   """A path, value pair.
 
   Attributes:
@@ -27,3 +29,9 @@ class PathValue(collections.namedtuple('PathValue', ['path', 'value'])):
   """
   def __str__(self):
     return '"{0}"={1!r}'.format(self.path, self.value)
+
+  def export_to_json_snapshot(self, snapshot, entity):
+    """Implements JsonSnapshotable interface."""
+    snapshot.edge_builder.make_control(entity, 'Path', self.path)
+    snapshot.edge_builder.make_data(entity, 'Value', self.value,
+                                    format='json')

--- a/citest/json_contract/path_predicate.py
+++ b/citest/json_contract/path_predicate.py
@@ -14,10 +14,11 @@
 
 """Support module for locating JSON objects that have certain field values."""
 
+from . import binary_predicate
 from . import lookup_predicate as lookup
 from . import path_predicate_result
 from . import predicate
-from . import quantification_predicate
+from . import quantification_predicate2
 
 
 class PathPredicate(predicate.ValuePredicate):
@@ -34,6 +35,11 @@ class PathPredicate(predicate.ValuePredicate):
   @property
   def pred(self):
     return self._pred
+
+  def export_to_json_snapshot(self, snapshot, entity):
+    """Implements JsonSnapshotable interface."""
+    snapshot.edge_builder.make_control(entity, 'Path', self._path)
+    snapshot.edge_builder.make_mechanism(entity, 'Predicate', self._pred)
 
   def _make_scribe_parts(self, scribe):
     parts = [scribe.build_part('Path', self._path,
@@ -117,4 +123,4 @@ class PathElementsContainPredicate(PathPredicate):
   """Specialization of PathPredicate that forces EXISTS_CONTAINS predicate."""
   def __init__(self, path, operand):
     super(PathElementsContainPredicate, self).__init__(
-        path, quantification_predicate.EXISTS_CONTAINS(operand))
+        path, quantification_predicate2.EXISTS_CONTAINS(operand))

--- a/citest/json_contract/path_predicate_result.py
+++ b/citest/json_contract/path_predicate_result.py
@@ -38,6 +38,13 @@ class JsonPathResult(predicate.PredicateResult):
   def source(self):
     return self._source
 
+  def export_to_json_snapshot(self, snapshot, entity):
+    builder = snapshot.edge_builder
+    builder.make_control(entity, 'Path', self._path)
+    builder.make_input(entity, 'Source', self._source, format='json')
+    builder.make_output(entity, 'Trace', self._path_trace)
+    super(JsonPathResult, self).export_to_json_snapshot(snapshot, entity)
+
   def _make_scribe_parts(self, scribe):
     parts = [scribe.build_part('Path', self._path,
                                relation=scribe.part_builder.CONTROL),
@@ -111,6 +118,12 @@ class JsonFoundValueResult(JsonPathResult):
   @property
   def pred(self):
     return self._pred
+
+  def export_to_json_snapshot(self, snapshot, entity):
+    snapshot.edge_builder.make_mechanism(entity, 'Predicate', self._pred)
+    snapshot.edge_builder.make_input(entity, 'Value', self._value,
+                                     format='json')
+    super(JsonFoundValueResult, self).export_to_json_snapshot(snapshot, entity)
 
   def _make_scribe_parts(self, scribe):
     parts = [scribe.build_part('Predicate', self._pred,

--- a/citest/json_contract/quantification_predicate.py
+++ b/citest/json_contract/quantification_predicate.py
@@ -74,6 +74,14 @@ class UniversalOrExistentialPredicate(predicate.ValuePredicate):
             and self._is_universal == op._is_universal
             and self._element_pred == op._element_pred)
 
+  def export_to_json_snapshot(self, snapshot, entity):
+    builder = snapshot.edge_builder
+    # 2200 is FORALL
+    # 2203 is EXISTS
+    builder.make_control(
+        entity, 'Operator', u'\u2200' if self._is_universal else u'\u2203')
+    builder.make_mechanism(entity, 'Elem Pred', self._element_pred)
+
   def _apply_existential(self, value):
     """Helper function that interprets predicate as existential predicate.
 

--- a/citest/json_contract/value_observation_verifier.py
+++ b/citest/json_contract/value_observation_verifier.py
@@ -42,6 +42,20 @@ class ValueObservationVerifierBuilder(ov.ObservationVerifierBuilder):
           unmapped_constraints=self._constraints,
           strict=self._strict)
 
+  def export_to_json_snapshot(self, snapshot, entity):
+    """Implements JsonSnapshotable interface."""
+    snapshot.edge_builder.make_control(entity, 'Strict', self._strict)
+    if len(self._constraints) == 1:
+      # Optimize model for single-element list
+      snapshot.edge_builder.make_control(
+        entity, 'Constraint', self._constraints[0])
+    else:
+      snapshot.edge_builder.make_control(
+        entity, 'Constraints', self._constraints)
+
+    super(ValueObserverVerifierBuilder, self).export_to_json_snapshot(
+        snapshot, entity)
+
   def _make_scribe_parts(self, scribe):
     parts = [scribe.build_part('Strict', self._strict,
                                relation=scribe.part_builder.CONTROL),
@@ -113,6 +127,14 @@ class ValueObservationVerifier(ov.ObservationVerifier):
   @property
   def strict(self):
     return self._strict
+
+  def export_to_json_snapshot(self, snapshot, entity):
+    """Implements JsonSnapshotable interface."""
+    snapshot.edge_builder.make_control(entity, 'Strict', self._strict)
+    snapshot.edge_builder.make_control(
+        entity, 'Constraints', self._constraints)
+    super(ValueObservationVerifier, self).export_to_json_snapshot(
+        snapshot, entity)
 
   def _make_scribe_parts(self, scribe):
     parts = [scribe.build_part('Strict', self._strict,

--- a/tests/json_contract/binary_predicate_test.py
+++ b/tests/json_contract/binary_predicate_test.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-import citest.base.scribe
+from citest.base import JsonSnapshotHelper
 import citest.json_contract as jc
 import citest.json_contract.binary_predicate as bp
 
@@ -36,10 +36,8 @@ def bad_result(value, pred):
 
 
 class JsonBinaryPredicateTest(unittest.TestCase):
-  def assertEqual(self, a, b, msg=''):
-    if not msg:
-      msg = 'EXPECTED\n{0}\n\nGOT\n{1}'.format(a, b)
-    super(JsonBinaryPredicateTest, self).assertEqual(a, b, msg)
+  def assertEqual(self, expect, have, msg=''):
+    JsonSnapshotHelper.AssertExpectedValue(expect, have, msg)
 
   def assertGoodResult(self, expect_value, pred, got_result):
     """Assert that got_result is expect_value returned by pred as valid."""

--- a/tests/json_contract/contract_test.py
+++ b/tests/json_contract/contract_test.py
@@ -14,7 +14,8 @@
 
 
 import unittest
-from citest.base import Scribe
+
+from citest.base import JsonSnapshotHelper
 import citest.json_contract as jc
 
 
@@ -39,12 +40,8 @@ class FakeObserver(jc.ObjectObserver):
 
 
 class JsonContractTest(unittest.TestCase):
-  def assertEqual(self, a, b, msg=''):
-    if not msg:
-      scribe = Scribe()
-      msg = 'EXPECT\n{0}\nGOT\n{1}'.format(
-        scribe.render_to_string(a), scribe.render_to_string(b))
-    super(JsonContractTest, self).assertEqual(a, b, msg)
+  def assertEqual(self, expect, have, msg=''):
+    JsonSnapshotHelper.AssertExpectedValue(expect, have, msg)
 
   def test_clause_success(self):
     observation = jc.Observation()

--- a/tests/json_contract/logic_predicate_test.py
+++ b/tests/json_contract/logic_predicate_test.py
@@ -14,20 +14,17 @@
 
 
 import unittest
+
+from citest.base import JsonSnapshotHelper
 import citest.json_contract as jc
-from citest.base import Scribe
 
 
 _LETTER_DICT = { 'a':'A', 'b':'B', 'z':'Z' }
 
 
 class LogicPredicateTest(unittest.TestCase):
-  def assertEqual(self, a, b, msg=''):
-    if not msg:
-      msg = 'EXPECTED\n{0}\n\nACTUAL\n{1}'.format(
-          Scribe().render_to_string(a),
-          Scribe().render_to_string(b))
-    super(LogicPredicateTest, self).assertEqual(a, b, msg)
+  def assertEqual(self, expect, have, msg=''):
+    JsonSnapshotHelper.AssertExpectedValue(expect, have, msg)
 
   def test_conjunction_true(self):
     aA = jc.PathEqPredicate('a', 'A')
@@ -47,7 +44,7 @@ class LogicPredicateTest(unittest.TestCase):
     bB = jc.PathEqPredicate('b', 'B')
     conjunction = jc.AND([aA, b2, bB])
     expect = jc.CompositePredicateResult(
-        valid=True, pred=conjunction,
+        valid=False, pred=conjunction,
         results=[aA(_LETTER_DICT), b2(_LETTER_DICT)])
 
     result = conjunction(_LETTER_DICT)

--- a/tests/json_contract/map_predicate_test.py
+++ b/tests/json_contract/map_predicate_test.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from citest.base import Scribe
+from citest.base import JsonSnapshotHelper
 import citest.json_contract as jc
 import citest.json_contract.map_predicate as mp
 
@@ -32,10 +32,8 @@ _MULTI_ARRAY = [ _LETTER_DICT, _NUMBER_DICT, _LETTER_DICT, _NUMBER_DICT]
 
 
 class JsonMapPredicateTest(unittest.TestCase):
-  def assertEqual(self, a, b, msg=''):
-    if not msg:
-      msg = 'EXPECT\n{0}\nGOT\n{1}'.format(a, b)
-    super(JsonMapPredicateTest, self).assertEqual(a, b, msg)
+  def assertEqual(self, expect, have, msg=''):
+    JsonSnapshotHelper.AssertExpectedValue(expect, have, msg)
 
   def _try_map(self, pred, obj, expect_ok, expect_map_result=None,
                   dump=False, min=1):
@@ -51,13 +49,11 @@ class JsonMapPredicateTest(unittest.TestCase):
     """
     map_result = jc.MapPredicate(pred, min=min)(obj)
     if dump:
-      print 'MAP_RESULT:\n{0}\n'.format(Scribe().render_to_string(map_result))
+      print 'MAP_RESULT:\n{0}\n'.format(
+        JsonSnapshotHelper.ValueToEncodedJson(map_result))
 
     if expect_map_result:
-      self.assertEqual(
-        expect_map_result, map_result,
-        '\nEXPECT {0}\n\nACTUAL {1}'.format(
-            expect_map_result, map_result))
+      self.assertEqual(expect_map_result, map_result)
     error_msg = '{expect_ok} != {ok}\n{map_result}'.format(
       expect_ok=expect_ok, ok=map_result.__nonzero__(),
       map_result=map_result)
@@ -66,10 +62,11 @@ class JsonMapPredicateTest(unittest.TestCase):
   def test_map_predicate_good_1(self):
     aA = jc.PathPredicate('a', jc.STR_EQ('A'))
 
+    aA_attempt = mp.ObjectResultMapAttempt(_LETTER_DICT, aA(_LETTER_DICT))
     expect_result = mp.MapPredicateResult(
       valid=True, pred=aA,
-      obj_list=[_LETTER_DICT], all_results=[aA(_LETTER_DICT)],
-      good_map=[mp.ObjectResultMapAttempt(_LETTER_DICT, aA(_LETTER_DICT))],
+      obj_list=[_LETTER_DICT], all_results=[aA_attempt.result],
+      good_map=[aA_attempt],
       bad_map=[])
 
     self._try_map(aA, _LETTER_DICT, True, expect_result)
@@ -78,7 +75,7 @@ class JsonMapPredicateTest(unittest.TestCase):
     aA = jc.PathPredicate('a', jc.STR_EQ('A'))
 
     expect_result = mp.MapPredicateResult(
-      valid=True, pred=aA,
+      valid=False, pred=aA,
       obj_list=[_NUMBER_DICT], all_results=[aA(_NUMBER_DICT)],
       bad_map=[mp.ObjectResultMapAttempt(_NUMBER_DICT, aA(_NUMBER_DICT))],
       good_map=[])
@@ -88,12 +85,16 @@ class JsonMapPredicateTest(unittest.TestCase):
   def test_map_predicate_good_and_bad_min_1(self):
     aA = jc.PathPredicate('a', jc.STR_EQ('A'))
 
+    aa_number_attempt = mp.ObjectResultMapAttempt(_NUMBER_DICT,
+                                                  aA(_NUMBER_DICT))
+    aa_letter_attempt = mp.ObjectResultMapAttempt(_LETTER_DICT,
+                                                  aA(_LETTER_DICT))
     expect_result = mp.MapPredicateResult(
       valid=True, pred=aA,
       obj_list=[_NUMBER_DICT, _LETTER_DICT],
-      all_results=[aA(_NUMBER_DICT), aA(_LETTER_DICT)],
-      good_map=[mp.ObjectResultMapAttempt(_LETTER_DICT, aA(_LETTER_DICT))],
-      bad_map=[mp.ObjectResultMapAttempt(_NUMBER_DICT, aA(_NUMBER_DICT))])
+      all_results=[aa_number_attempt.result, aa_letter_attempt.result],
+      good_map=[aa_letter_attempt],
+      bad_map=[aa_number_attempt])
 
     self._try_map(aA, [_NUMBER_DICT, _LETTER_DICT], True, expect_result)
 
@@ -113,11 +114,12 @@ class JsonMapPredicateTest(unittest.TestCase):
   def test_map_not_found(self):
     aA = jc.PathPredicate('a', jc.STR_EQ('A'))
 
+    aa_composite_attempt = mp.ObjectResultMapAttempt(_COMPOSITE_DICT,
+                                                     aA(_COMPOSITE_DICT))
     expect_result = mp.MapPredicateResult(
-      valid=True, pred=aA,
-      obj_list=[_COMPOSITE_DICT], all_results=[aA(_COMPOSITE_DICT)],
-      bad_map=[mp.ObjectResultMapAttempt(_COMPOSITE_DICT,
-                                          aA(_COMPOSITE_DICT))],
+      valid=False, pred=aA,
+      obj_list=[_COMPOSITE_DICT], all_results=[aa_composite_attempt.result],
+      bad_map=[aa_composite_attempt],
       good_map=[])
 
     self._try_map(aA, _COMPOSITE_DICT, False, expect_result)

--- a/tests/json_contract/observation_verifier_test.py
+++ b/tests/json_contract/observation_verifier_test.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from citest.base import Scribe
+from citest.base import JsonSnapshotHelper
 import citest.json_contract as jc
 
 _called_verifiers = []
@@ -46,13 +46,8 @@ class FakeObservationVerifier(jc.ObservationVerifier):
 
 
 class ObservationVerifierTest(unittest.TestCase):
-  def assertEqual(self, a, b, msg=''):
-    if not msg:
-      scribe = Scribe()
-      msg = 'EXPECT\n{0}\nGOT\n{1}'.format(
-        scribe.render_to_string(a),
-        scribe.render_to_string(b))
-    super(ObservationVerifierTest, self).assertEqual(a, b, msg)
+  def assertEqual(self, expect, have, msg=''):
+    JsonSnapshotHelper.AssertExpectedValue(expect, have, msg)
 
   def test_result_builder_add_good_result(self):
       observation = jc.Observation()

--- a/tests/json_contract/path_predicate_test.py
+++ b/tests/json_contract/path_predicate_test.py
@@ -14,7 +14,10 @@
 
 
 import unittest
+
+from citest.base import JsonSnapshotHelper
 import citest.json_contract as jc
+
 
 _LETTER_ARRAY = ['a', 'b', 'c']
 _LETTER_DICT = {'a': 'A', 'b': 'B', 'z': 'Z'}
@@ -32,10 +35,8 @@ def _make_found(source, path_trace, pred, valid=True):
 
 
 class JsonPathPredicateTest(unittest.TestCase):
-  def assertEqual(self, a, b, msg=''):
-    if not msg:
-      msg = 'EXPECTED\n{0}\n\nGOT\n{1}'.format(a, b)
-    super(JsonPathPredicateTest, self).assertEqual(a, b, msg)
+  def assertEqual(self, expect, have, msg=''):
+    JsonSnapshotHelper.AssertExpectedValue(expect, have, msg)
 
   def test_clone_type_mismatch_none_context(self):
     result = jc.JsonTypeMismatchResult(list, dict, 'ORIGINAL')

--- a/tests/json_contract/value_observation_verifier_test.py
+++ b/tests/json_contract/value_observation_verifier_test.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from citest.base import Scribe
+from citest.base import JsonSnapshotHelper
 import citest.json_contract as jc
 
 
@@ -31,12 +31,8 @@ _MULTI_ARRAY = [ _LETTER_DICT, _NUMBER_DICT, _LETTER_DICT, _NUMBER_DICT]
 
 
 class JsonValueObservationVerifierTest(unittest.TestCase):
-  def assertEqual(self, a, b, msg=''):
-    if not msg:
-      msg = 'EXPECT\n{0}\nGOT\n{1}'.format(
-        Scribe().render_to_string(a),
-        Scribe().render_to_string(b))
-    super(JsonValueObservationVerifierTest, self).assertEqual(a, b, msg)
+  def assertEqual(self, expect, have, msg=''):
+    JsonSnapshotHelper.AssertExpectedValue(expect, have, msg)
 
   def test_verifier_builder_add_constraint(self):
       aA = jc.PathPredicate('a', jc.STR_EQ('A'))
@@ -267,17 +263,13 @@ class JsonValueObservationVerifierTest(unittest.TestCase):
     self.assertEqual(verify_results.observation, observation)
 
     ok = verify_results.__nonzero__()
-    scribe = Scribe()
-    error_msg = '{expect_ok}!={ok}\n{errors}'.format(
-        expect_ok=expect_ok, ok=ok,
-        errors=scribe.render_to_string(verify_results.bad_results))
     if dump:
       print 'GOT RESULTS:\n{0}\n'.format(
-          scribe.render_to_string(verify_results))
-      print '\nEXPECTED:\n{0}\n'.format(
-          scribe.render_to_string(expect_results))
+        JsonSnapshotHelper.ValueToEncodedJson(verify_results))
+      print '\nExpected:\n{0}\n'.format(
+        JsonSnapshotHelper.ValueToEncodedJson(expect_results))
 
-    self.assertEqual(expect_ok, ok, error_msg)
+    self.assertEqual(expect_ok, ok)
     if expect_results:
       self.assertEqual(expect_results, verify_results)
 


### PR DESCRIPTION
…cribe.

This is mostly a port of the scribes (_make_scribe_parts method), but I tweaked
the data model a bit, and added more metadata. Also I optimized some
abstractions by flattening out lists that only contained one element to make
the model easier to navigate.

I also removed scribes from the tests, and use the snapshots instead.
This forced me to refactor how I was constructing some expected values.
The tests and values are the same, but the actual data model is different.
The snapshots capture actual references, not value references. So equivalent
values are not enough for the test to pass. The reasons the values are
equivalent (internally referencing the same object) is also implied by the
snapshot.

Also some whitespace formatting changes to please pylint.
