### PR TITLE
Added snapshotting to service_testing package.

### DIFF
--- a/citest/service_testing/http_observer.py
+++ b/citest/service_testing/http_observer.py
@@ -46,6 +46,12 @@ class HttpObjectObserver(jc.ObjectObserver):
   def __str__(self):
     return 'HttpObjectObserver({0})'.format(self.__agent)
 
+  def export_to_json_snapshot(self, snapshot, entity):
+    """Implements JsonSnapshotable interface."""
+    snapshot.edge_builder.make_mechanism(entity, 'Agent', self.__agent)
+    snapshot.edge_builder.make_control(entity, 'Path', self.__path)
+    super(HttpObjectObserver, self).export_to_json_snapshot(snapshot, entity)
+
   def _make_scribe_parts(self, scribe):
     parts = [scribe.part_builder.build_mechanism_part('Agent:', self.__agent),
              scribe.part_builder.build_control_part('Path:', self.__path)]

--- a/citest/service_testing/operation_contract.py
+++ b/citest/service_testing/operation_contract.py
@@ -16,9 +16,10 @@
 """Specifies test cases using TestableAgents."""
 
 from ..base.scribe import Scribable
+from ..base import JsonSnapshotable
 
 
-class OperationContract(Scribable):
+class OperationContract(Scribable, JsonSnapshotable):
   """Specifies a testable operation and contract to verify it.
 
   This is essentially a "test case" using  TestableAgents.
@@ -37,6 +38,11 @@ class OperationContract(Scribable):
   def contract(self):
     """The json.Contract to verify the operation."""
     return self._contract
+
+  def export_to_json_snapshot(self, snapshot, entity):
+    """Implements JsonSnapshotable interface."""
+    snapshot.edge_builder.make(entity, 'Operation', self._operation)
+    snapshot.edge_builder.make(entity, 'Contract', self._contract)
 
   def _make_scribe_parts(self, scribe):
     """Implements Scribbable_make_scribe_parts interface."""


### PR DESCRIPTION
@lwander 
Use snapshotting in service_testing module.
This is in part a port from the scribe, but also adds an execution trace object with individual attempts to capture all the attempt detail whereas before it only captured the first and maybe last.
