### PR TITLE
Fixed JenkinsAgent snapshot, and clarified test failure reporting.

### DIFF
--- a/spinnaker/spinnaker_system/bake_and_deploy_test.py
+++ b/spinnaker/spinnaker_system/bake_and_deploy_test.py
@@ -381,7 +381,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
 
     return st.OperationContract(
         self.new_post_operation(
-            title='create_bake_pipeline', data=payload, path='pipelines',
+            title='create_bake_docker_pipeline', data=payload, path='pipelines',
             status_class=st.SynchronousHttpOperationStatus),
         contract=builder.build())
 
@@ -420,7 +420,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
 
     return st.OperationContract(
         self.new_post_operation(
-            title='create_bake_pipeline', data=payload, path='pipelines',
+            title='create_bake_google_pipeline', data=payload, path='pipelines',
             status_class=st.SynchronousHttpOperationStatus),
         contract=builder.build())
 
@@ -459,7 +459,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
 
     return st.OperationContract(
         self.new_post_operation(
-            title='create_bake_pipeline', data=payload, path='pipelines',
+            title='create_bake_aws_pipeline', data=payload, path='pipelines',
             status_class=st.SynchronousHttpOperationStatus),
         contract=builder.build())
 


### PR DESCRIPTION
There are a few disparate changes here that may as well happen before I
submit the integration CL that makes snapshot reporting live.
- Jenkins agent had a typo in it, This was the only critical bug that needs
  to be submitted first.
- Hooked up snapshotting in TestableAgent and reworked HttpAgent so that
  you can specify the payload format (e.g. json) so that it can snapshot
  directly instead of having consumers snapshot on its behalf.
- Reworked the test control loop so that it more cleanly reports errors and
  exceptions. Before they were combined together (reporting happened after
  verification, so exceptions were double reported as both failures and
  exceptions). Now AssertErrors are raised after reporting, where failures
  are already reported. Only non-assertion errors are reported as exceptions.
