### PR TITLE
give some slop for GCE to mark an instances as stopping.

### DIFF
--- a/spinnaker/spinnaker_system/kato_test.py
+++ b/spinnaker/spinnaker_system/kato_test.py
@@ -189,6 +189,7 @@ class KatoTestScenario(sk.SpinnakerTestScenario):
       st.OperationContract
     """
     builder = gcp.GceContractBuilder(self.gce_observer)
+    builder.retryable_for_secs = 15
     clause = (builder.new_clause_builder('Instances Deleted', strict=True)
               .list_resources('instances'))
     for name in names:


### PR DESCRIPTION
@duftler 
Test failed because the instance was still RUNNING after spinnaker returned.
Not really sure if this is a GCE bug or not. Gave some slop in the test to allow for eventual completion.
