### PR TITLE
Add NoOpOperation

### DIFF
--- a/citest/gcp_testing/gce_util.py
+++ b/citest/gcp_testing/gce_util.py
@@ -281,7 +281,7 @@ def establish_network_connectivity(gcloud, instance, target_port):
 
   logger.debug('Confirming tunnel is working')
   url = 'http://localhost:%d' % local_port
-  for i in range(5):
+  for i in range(15):
     try:
       response = urllib2.urlopen(url, None, 10)
       logger.debug('Confirmed availability (%d)', response.getcode())

--- a/citest/reporting/html_renderer.py
+++ b/citest/reporting/html_renderer.py
@@ -140,7 +140,7 @@ class ProcessToRenderInfo(object):
     self.max_uncollapsable_entity_rows = 0  # Num attributes within an entity.
     self.max_uncollapsable_metadata_rows = 0  # Num metadata keys.
     self.max_uncollapsable_message_lines = 0  # Always collapse log messages.
-    self.max_message_summary_length = 100
+    self.max_message_summary_length = 60
 
   def determine_default_expanded(self, relation):
     """Determine whether entities should be expanded by default or not.

--- a/citest/service_testing/__init__.py
+++ b/citest/service_testing/__init__.py
@@ -28,7 +28,7 @@ invocation of command-line programs.
 """
 
 # The testable_agent module contains the base definitions.
-from .testable_agent import(
+from testable_agent import(
     AgentError,
     AgentOperation,
     AgentOperationStatus,
@@ -36,7 +36,7 @@ from .testable_agent import(
 
 
 # The cli_agent module implements an agent that uses command-line programs.
-from .cli_agent import (
+from cli_agent import (
     CliAgent,
     CliAgentObservationFailureVerifier,
     CliAgentRunError,
@@ -46,7 +46,7 @@ from .cli_agent import (
 
 
 # The cli_agent module implements an agent that uses HTTP messaging.
-from .http_agent import (
+from http_agent import (
     HttpAgent,
     HttpDeleteOperation,
     HttpOperationStatus,
@@ -54,23 +54,25 @@ from .http_agent import (
     HttpResponseType,
     SynchronousHttpOperationStatus)
 
-from .http_observer import (
+from http_observer import (
     HttpObjectObserver,
     HttpContractBuilder,
     HttpContractClauseBuilder,
     )
 
-from .http_scrubber import (
+from http_scrubber import (
     DefaultHttpHeadersScrubber,
     HttpScrubber)
 
 # The operation_contract module combines AgentOperation and JsonContract.
-from .operation_contract import OperationContract
+from operation_contract import OperationContract
 
+# A NoOpOperation can be used to create a contract for an invariant.
+from nop_operation import NoOpOperation
 
 # The service_testing module adds support for writing tests with TestableAgent.
-from .agent_test_case import (
+from agent_test_case import (
     AgentTestCase,
     AgentTestScenario)
 
-from .scenario_test_runner import ScenarioTestRunner
+from scenario_test_runner import ScenarioTestRunner

--- a/citest/service_testing/http_observer.py
+++ b/citest/service_testing/http_observer.py
@@ -39,6 +39,7 @@ class HttpObjectObserver(jc.ObjectObserver):
       agent: [HttpAgent] Instance to use.
       path: [string] Path to GET from server that agent is bound to.
     """
+    # pylint: disable=redefined-builtin
     super(HttpObjectObserver, self).__init__(filter)
     self.__agent = agent
     self.__path = path
@@ -57,7 +58,8 @@ class HttpObjectObserver(jc.ObjectObserver):
     # collect some thing out of the results.
     result = self.agent.get(self.__path, trace=trace)
     if not result.ok():
-      error = 'Observation failed with HTTP %d.' % result.retcode
+      error = 'Observation failed with HTTP %d.\n%s' % (result.retcode,
+                                                        result.error)
       logging.getLogger(__name__).error(error)
       observation.add_error(AgentError(error))
       return []

--- a/citest/service_testing/nop_operation.py
+++ b/citest/service_testing/nop_operation.py
@@ -1,0 +1,76 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A no-op operation does nothing. It is intended for observing invariants."""
+
+import testable_agent
+
+
+class ConstantOperationStatus(testable_agent.AgentOperationStatus):
+  """An operation status meant for a NoOp operation.
+
+  By default this is simply success. It could be configured to be an error.
+  """
+
+  @property
+  def finished(self):
+    """Implments AgentOperationStatus interface."""
+    return True
+
+  @property
+  def finished_ok(self):
+    """Implments AgentOperationStatus interface."""
+    return self.__error is None
+
+  @property
+  def timed_out(self):
+    """Implments AgentOperationStatus interface."""
+    return False
+
+  @property
+  def detail(self):
+    """Implments AgentOperationStatus interface."""
+    return self.__detail
+
+  @property
+  def id(self):
+    """Implments AgentOperationStatus interface."""
+    return self.__id
+
+
+  def __init__(self, operation, id='no-op', detail=None, error=None):
+    """Constructor."""
+    # pylint: disable=redefined-builtin
+    super(ConstantOperationStatus, self).__init__(operation)
+    self.__id = id
+    self.__detail = detail
+    self.__error = error
+
+
+class NoOpOperation(testable_agent.AgentOperation):
+  """Implements an operation that succeeds without doing anything.
+
+  This is intended to test invariants as a contract. The invariant is
+  associated with this operation, thus can be tested using the same techniques
+  as other interactions with the server that produce side effects.
+  """
+
+  def execute(self, agent=None):
+    """Implments AgentOperation interface.
+
+    Args:
+      agent: [ignored] Complies with the AgentOperation interface.
+    """
+    # pylint: disable=unused-argument
+    return ConstantOperationStatus(self)

--- a/citest/service_testing/testable_agent.py
+++ b/citest/service_testing/testable_agent.py
@@ -233,12 +233,19 @@ class AgentOperationStatus(JsonSnapshotable):
     context_relation = 'ERROR'
     try:
       self.refresh(trace=trace_first)
-      ok = self.__wait_helper(poll_every_secs, max_secs, trace_every)
-      context_relation = 'VALID' if ok else 'INVALID'
+      good = self.__wait_helper(poll_every_secs, max_secs, trace_every)
+      context_relation = 'VALID' if good else 'INVALID'
     finally:
       JournalLogger.end_context(relation=context_relation)
 
   def __wait_helper(self, poll_every_secs, max_secs, trace):
+    """Helper function for wait to keep its try/finally block simple.
+
+    Args:
+      poll_every_secs: [int] Frequency to poll.
+      max_secs: [int] How long to poll before giving up.
+      trace_every: [bool] Whether to log each attempt.
+    """
     logger = logging.getLogger(__name__)
     secs_remaining = max_secs
     log_secs_remaining = 0
@@ -340,13 +347,17 @@ class AgentOperation(JsonSnapshotable):
         entity, 'Agent Class', self.agent.__class__.__name__)
     builder.make_control(entity, 'Max Wait Secs', self.max_wait_secs)
 
-  def execute(self):
+  def execute(self, agent=None):
     """Have the bound agent perform this operation.
 
     This method must be specialized.
 
+    Args:
+      agent: [TestableAgent] If provided, use instead of the one bound.
+
     Returns:
       OperationStatus for this invocation.
     """
+    # pylint: disable=unused-argument
     raise NotImplementedError(
         'execute was not specialized on {0}.'.format(self.__class__))

--- a/spinnaker/spinnaker_system/smoke_test.py
+++ b/spinnaker/spinnaker_system/smoke_test.py
@@ -102,12 +102,10 @@ class SmokeTestScenario(sk.SpinnakerTestScenario):
         contract=contract)
 
   def create_load_balancer(self):
-    load_balancer_name = self.bindings['TEST_APP_COMPONENT_NAME']
-    target_pool_name = '{0}/targetPools/{1}-tp'.format(
-        self.bindings['TEST_GCE_REGION'], load_balancer_name)
-
     bindings = self.bindings
-    account_name = bindings['GCE_CREDENTIALS']
+    load_balancer_name = bindings['TEST_APP_COMPONENT_NAME']
+    target_pool_name = '{0}/targetPools/{1}-tp'.format(
+        bindings['TEST_GCE_REGION'], load_balancer_name)
 
     spec = {
       'checkIntervalSec': 9,


### PR DESCRIPTION
Reimplemented kato available image test using a no-op operation and contract
so that it follows the citest test pattern.

@lwander 
