### PR TITLE
Renamed verifier contains* excludes* methods

### DIFF
--- a/citest/json_contract/value_observation_verifier.py
+++ b/citest/json_contract/value_observation_verifier.py
@@ -69,40 +69,41 @@ class ValueObservationVerifierBuilder(ov.ObservationVerifierBuilder):
         map_predicate.MapPredicate(pred=constraint, min=min, max=max))
     return self
 
-  def contains(self, path, value, min=1, max=None):
-    return self.contains_pred(
+  def contains_path_value(self, path, value, min=1, max=None):
+    return self.contains_path_pred(
         path, binary_predicate.CONTAINS(value), min, max)
 
-  def contains_eq(self, path, value, min=1, max=None):
-    return self.contains_pred(
+  def contains_path_eq(self, path, value, min=1, max=None):
+    return self.contains_path_pred(
         path, binary_predicate.EQUIVALENT(value), min, max)
 
-  def contains_pred(self, path, pred, min=1, max=None):
+  def contains_path_pred(self, path, pred, min=1, max=None):
     self.add_constraint(
       cardinality_predicate.CardinalityPredicate(
           path_predicate.PathPredicate(path, pred), min=min, max=max))
     return self
 
-  def contains_group(self, pred_list, min=1, max=None):
+  def contains_pred_list(self, pred_list, min=1, max=None):
     conjunction = logic_predicate.AND(pred_list)
     self.add_constraint(
         cardinality_predicate.CardinalityPredicate(
             conjunction, min=min, max=max))
     return self
 
-  def excludes_pred(self, path, pred, max=0):
+  def excludes_path_pred(self, path, pred, max=0):
     self.add_constraint(
         cardinality_predicate.CardinalityPredicate(
             path_predicate.PathPredicate(path, pred), min=0, max=max))
     return self
 
-  def excludes(self, path, value, max=0):
-    return self.excludes_pred(path, binary_predicate.CONTAINS(value), max)
+  def excludes_path_value(self, path, value, max=0):
+    return self.excludes_path_pred(path, binary_predicate.CONTAINS(value), max)
 
-  def excludes_eq(self, path, value, max=0):
-    return self.excludes_pred(path, binary_predicate.EQUIVALENT(value), max)
+  def excludes_path_eq(self, path, value, max=0):
+    return self.excludes_path_pred(
+        path, binary_predicate.EQUIVALENT(value), max)
 
-  def excludes_group(self, pred_list, max=0):
+  def excludes_pred_list(self, pred_list, max=0):
     conjunction = logic_predicate.AND(pred_list)
     self.add_constraint(
         cardinality_predicate.CardinalityPredicate(

--- a/spinnaker/spinnaker_system/aws_kato_test.py
+++ b/spinnaker/spinnaker_system/aws_kato_test.py
@@ -151,7 +151,7 @@ class AwsKatoTestScenario(sk.SpinnakerTestScenario):
          aws_module='elb',
          command='describe-load-balancers',
          args=['--load-balancer-names', self.__use_lb_name])
-     .contains_group([
+     .contains_pred_list([
          jc.PathContainsPredicate(
              'LoadBalancerDescriptions/HealthCheck', health_check),
          jc.PathEqPredicate(
@@ -188,7 +188,7 @@ class AwsKatoTestScenario(sk.SpinnakerTestScenario):
          command='describe-load-balancers',
          args=['--load-balancer-names', self.__use_lb_name],
          no_resources_ok=True)
-     .excludes('LoadBalancerName', self.__use_lb_name))
+     .excludes_path_value('LoadBalancerName', self.__use_lb_name))
 
     return st.OperationContract(
         self.new_post_operation(

--- a/spinnaker/spinnaker_system/aws_smoke_test.py
+++ b/spinnaker/spinnaker_system/aws_smoke_test.py
@@ -204,7 +204,7 @@ class AwsSmokeTestScenario(sk.SpinnakerTestScenario):
          aws_module='elb',
          command='describe-load-balancers',
          args=['--load-balancer-names', load_balancer_name])
-     .contains_group([
+     .contains_pred_list([
          jc.PathContainsPredicate(
              'LoadBalancerDescriptions/HealthCheck', health_check),
          jc.PathEqPredicate(
@@ -248,7 +248,7 @@ class AwsSmokeTestScenario(sk.SpinnakerTestScenario):
          command='describe-load-balancers',
          args=['--load-balancer-names', load_balancer_name],
          no_resources_ok=True)
-     .excludes('LoadBalancerName', load_balancer_name))
+     .excludes_path_value('LoadBalancerName', load_balancer_name))
 
     return st.OperationContract(
         self.new_post_operation(
@@ -318,7 +318,7 @@ class AwsSmokeTestScenario(sk.SpinnakerTestScenario):
                                 retryable_for_secs=30)
      .collect_resources('autoscaling', 'describe-auto-scaling-groups',
                         args=['--auto-scaling-group-names', group_name])
-     .contains('AutoScalingGroups', {'MaxSize': 2}))
+     .contains_path_value('AutoScalingGroups', {'MaxSize': 2}))
 
     return st.OperationContract(
         self.new_post_operation(
@@ -354,12 +354,12 @@ class AwsSmokeTestScenario(sk.SpinnakerTestScenario):
      .collect_resources('autoscaling', 'describe-auto-scaling-groups',
                         args=['--auto-scaling-group-names', group_name],
                         no_resources_ok=True)
-     .contains('AutoScalingGroups', {'MaxSize': 0}))
+     .contains_path_value('AutoScalingGroups', {'MaxSize': 0}))
 
     (builder.new_clause_builder('Instances Are Removed',
                                 retryable_for_secs=30)
      .collect_resources('ec2', 'describe-instances', no_resources_ok=True)
-     .excludes('name', group_name))
+     .excludes_path_value('name', group_name))
 
     return st.OperationContract(
         self.new_post_operation(

--- a/spinnaker/spinnaker_system/bake_and_deploy_test.py
+++ b/spinnaker/spinnaker_system/bake_and_deploy_test.py
@@ -158,7 +158,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
     builder = st.HttpContractBuilder(self.agent)
     (builder.new_clause_builder('Has Application', retryable_for_secs=60)
        .get_url_path('applications')
-       .contains('name', self.TEST_APP))
+       .contains_path_value('name', self.TEST_APP))
 
     return st.OperationContract(
         self.agent.make_create_app_operation(
@@ -215,12 +215,12 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
     (builder.new_clause_builder('Health Check Added',
                                 retryable_for_secs=30)
          .list_resources('http-health-checks')
-         .contains('name', load_balancer_name + '-hc'))
+         .contains_path_value('name', load_balancer_name + '-hc'))
 
     (builder.new_clause_builder('Load Balancer Created',
                                 retryable_for_secs=60)
          .list_resources('forwarding-rules')
-         .contains('name', self.__full_lb_name))
+         .contains_path_value('name', self.__full_lb_name))
 
     return st.OperationContract(
         self.new_post_operation(
@@ -249,7 +249,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
     builder = gcp.GceContractBuilder(self.gce_observer)
     (builder.new_clause_builder('Health Check Removed', retryable_for_secs=30)
          .list_resources('http-health-checks')
-         .excludes('name', self.__full_lb_name + '-hc'))
+         .excludes_path_value('name', self.__full_lb_name + '-hc'))
 
     return st.OperationContract(
         self.new_post_operation(
@@ -377,7 +377,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
     (builder.new_clause_builder('Has Pipeline')
        .get_url_path(
            'applications/{app}/pipelineConfigs'.format(app=self.TEST_APP))
-       .contains(None, pipeline_spec))
+       .contains_path_value(None, pipeline_spec))
 
     return st.OperationContract(
         self.new_post_operation(
@@ -416,7 +416,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
     (builder.new_clause_builder('Has Pipeline')
        .get_url_path(
            'applications/{app}/pipelineConfigs'.format(app=self.TEST_APP))
-       .contains(None, pipeline_spec))
+       .contains_path_value(None, pipeline_spec))
 
     return st.OperationContract(
         self.new_post_operation(
@@ -455,7 +455,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
     (builder.new_clause_builder('Has Pipeline')
        .get_url_path(
            'applications/{app}/pipelineConfigs'.format(app=self.TEST_APP))
-       .contains(None, pipeline_spec))
+       .contains_path_value(None, pipeline_spec))
 
     return st.OperationContract(
         self.new_post_operation(
@@ -471,7 +471,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
     (builder.new_clause_builder('Has Pipeline')
        .get_url_path(
            'applications/{app}/pipelineConfigs'.format(app=self.TEST_APP))
-       .excludes('name', pipeline_id))
+       .excludes_path_value('name', pipeline_id))
 
     return st.OperationContract(
         self.new_delete_operation(

--- a/spinnaker/spinnaker_system/kato_test.py
+++ b/spinnaker/spinnaker_system/kato_test.py
@@ -156,7 +156,7 @@ class KatoTestScenario(sk.SpinnakerTestScenario):
       (builder.new_clause_builder(
           'Instance %d Created' % i, retryable_for_secs=90)
             .list_resources('instances')
-            .contains('name', self.use_instance_names[i]))
+            .contains_path_value('name', self.use_instance_names[i]))
       if i < 2:
         # Verify the details are what we asked for.
         # Since we've finished the created clause, this already exists.
@@ -167,7 +167,7 @@ class KatoTestScenario(sk.SpinnakerTestScenario):
         (builder.new_clause_builder('Instance %d Details' % i)
             .inspect_resource('instances', self.use_instance_names[i],
                               extra_args=['--zone', self.use_instance_zones[i]])
-            .contains('machineType', machine_type[i]))
+            .contains_path_value('machineType', machine_type[i]))
         # Verify the instance eventually boots up.
         # We can combine this with above, but we'll probably need
         # to retry this, but not the above, so this way if the
@@ -176,7 +176,7 @@ class KatoTestScenario(sk.SpinnakerTestScenario):
                              retryable_for_secs=90)
             .inspect_resource('instances', name=self.use_instance_names[i],
                               extra_args=['--zone', self.use_instance_zones[i]])
-            .contains_eq('status', 'RUNNING'))
+            .contains_path_eq('status', 'RUNNING'))
 
     payload = self.agent.make_payload(instance_spec)
 
@@ -240,7 +240,7 @@ class KatoTestScenario(sk.SpinnakerTestScenario):
     builder = gcp.GceContractBuilder(self.gce_observer)
     (builder.new_clause_builder('Server Group Tags Added')
         .inspect_resource('managed-instance-groups', server_group_name)
-        .contains_group(
+        .contains_pred_list(
             [jc.PathContainsPredicate('name', server_group_name),
              jc.PathContainsPredicate(
                  "tags/items", ['test-tag-1', 'test-tag-2'])]))
@@ -306,29 +306,29 @@ class KatoTestScenario(sk.SpinnakerTestScenario):
     builder = gcp.GceContractBuilder(self.gce_observer)
     (builder.new_clause_builder('Http Health Check Added')
         .list_resources('http-health-checks')
-        .contains_group(
+        .contains_pred_list(
             [jc.PathContainsPredicate('name', self.__use_http_lb_hc_name),
              jc.PathContainsPredicate(None, health_check)]))
     (builder.new_clause_builder('Forwarding Rule Added', retryable_for_secs=15)
        .list_resources('forwarding-rules')
-       .contains_group(
+       .contains_pred_list(
            [jc.PathContainsPredicate('name', self.__use_http_lb_fr_name),
             jc.PathContainsPredicate('portRange', port_range)]))
     (builder.new_clause_builder('Backend Service Added')
        .list_resources('backend-services')
-       .contains_group(
+       .contains_pred_list(
            [jc.PathContainsPredicate('name', self.__use_http_lb_bs_name),
             jc.PathElementsContainPredicate(
                 'healthChecks', self.__use_http_lb_hc_name)]))
     (builder.new_clause_builder('Url Map Added')
        .list_resources('url-maps')
-       .contains_group(
+       .contains_pred_list(
            [jc.PathContainsPredicate('name', self.__use_http_lb_map_name),
             jc.PathContainsPredicate(
                 'defaultService', self.__use_http_lb_bs_name)]))
     (builder.new_clause_builder('Target Http Proxy Added')
        .list_resources('target-http-proxies')
-       .contains_group(
+       .contains_pred_list(
            [jc.PathContainsPredicate('name', self.__use_http_lb_proxy_name),
             jc.PathContainsPredicate('urlMap', self.__use_http_lb_map_name)]))
 
@@ -349,19 +349,19 @@ class KatoTestScenario(sk.SpinnakerTestScenario):
     builder = gcp.GceContractBuilder(self.gce_observer)
     (builder.new_clause_builder('Health Check Removed')
        .list_resources('http-health-checks')
-       .excludes('name', self.__use_http_lb_hc_name))
+       .excludes_path_value('name', self.__use_http_lb_hc_name))
     (builder.new_clause_builder('Forwarding Rules Removed')
        .list_resources('forwarding-rules')
-       .excludes('name', self.__use_http_lb_fr_name))
+       .excludes_path_value('name', self.__use_http_lb_fr_name))
     (builder.new_clause_builder('Backend Service Removed')
        .list_resources('backend-services')
-       .excludes('name', self.__use_http_lb_bs_name))
+       .excludes_path_value('name', self.__use_http_lb_bs_name))
     (builder.new_clause_builder('Url Map Removed')
        .list_resources('url-maps')
-       .excludes('name', self.__use_http_lb_map_name))
+       .excludes_path_value('name', self.__use_http_lb_map_name))
     (builder.new_clause_builder('Target Http Proxy Removed')
        .list_resources('target-http-proxies')
-       .excludes('name', self.__use_http_lb_proxy_name))
+       .excludes_path_value('name', self.__use_http_lb_proxy_name))
 
     return st.OperationContract(
         self.new_post_operation(
@@ -404,18 +404,19 @@ class KatoTestScenario(sk.SpinnakerTestScenario):
     (builder.new_clause_builder('Forwarding Rules Added',
                                 retryable_for_secs=30)
        .list_resources('forwarding-rules')
-       .contains('name', self.__use_lb_name)
-       .contains('target', self.__use_lb_target))
+       .contains_path_value('name', self.__use_lb_name)
+       .contains_path_value('target', self.__use_lb_target))
     (builder.new_clause_builder('Target Pool Added', retryable_for_secs=15)
        .list_resources('target-pools')
-       .contains('name', self.__use_lb_tp_name))
+       .contains_path_value('name', self.__use_lb_tp_name))
 
      # We list the resources here because the name isnt exact
      # and the list also returns the details we need.
     (builder.new_clause_builder('Health Check Added', retryable_for_secs=15)
        .list_resources('http-health-checks')
-       .contains_group([jc.PathContainsPredicate('name', self.__use_lb_hc_name),
-                        jc.PathContainsPredicate(None, health_check)]))
+       .contains_pred_list(
+           [jc.PathContainsPredicate('name', self.__use_lb_hc_name),
+            jc.PathContainsPredicate(None, health_check)]))
 
     return st.OperationContract(
       self.new_post_operation(
@@ -435,13 +436,13 @@ class KatoTestScenario(sk.SpinnakerTestScenario):
     builder = gcp.GceContractBuilder(self.gce_observer)
     (builder.new_clause_builder('Health Check Removed')
        .list_resources('http-health-checks')
-       .excludes('name', self.__use_lb_hc_name))
+       .excludes_path_value('name', self.__use_lb_hc_name))
     (builder.new_clause_builder('Target Pool Removed')
        .list_resources('target-pools')
-       .excludes('name', self.__use_lb_tp_name))
+       .excludes_path_value('name', self.__use_lb_tp_name))
     (builder.new_clause_builder('Forwarding Rule Removed')
        .list_resources('forwarding-rules')
-       .excludes('name', self.__use_lb_name))
+       .excludes_path_value('name', self.__use_lb_name))
 
     return st.OperationContract(
       self.new_post_operation(
@@ -474,14 +475,14 @@ class KatoTestScenario(sk.SpinnakerTestScenario):
     (builder.new_clause_builder('Instances in Target Pool',
                                 retryable_for_secs=15)
        .list_resources('target-pools')
-       .contains_group(
+       .contains_pred_list(
           [jc.PathContainsPredicate('name', self.__use_lb_tp_name),
            jc.PathEqPredicate('region', self.bindings['TEST_GCE_REGION']),
            jc.PathElementsContainPredicate(
               'instances', self.use_instance_names[0]),
            jc.PathElementsContainPredicate(
               'instances', self.use_instance_names[1])])
-       .excludes_group(
+       .excludes_pred_list(
            [jc.PathContainsPredicate('name', self.__use_lb_tp_name),
             jc.PathElementsContainPredicate(
                 'instances', self.use_instance_names[2])]))
@@ -519,7 +520,7 @@ class KatoTestScenario(sk.SpinnakerTestScenario):
        .list_resources(
           'target-pools',
           extra_args=['--region', self.bindings['TEST_GCE_REGION']])
-       .excludes_group(
+       .excludes_pred_list(
           [jc.PathContainsPredicate('name', self.__use_lb_tp_name),
            jc.PathElementsContainPredicate(
               'instances', self.use_instance_names[0]),

--- a/spinnaker/spinnaker_system/server_group_tests.py
+++ b/spinnaker/spinnaker_system/server_group_tests.py
@@ -75,7 +75,7 @@ class ServerGroupTestScenario(sk.SpinnakerTestScenario):
     builder = gcp.GceContractBuilder(self.gce_observer)
     (builder.new_clause_builder('Load Balancer Created', retryable_for_secs=30)
      .list_resources('forwarding-rules')
-     .contains('name', self.__lb_name))
+     .contains_path_value('name', self.__lb_name))
 
     payload = self.agent.make_payload(
         job=job, description='Server Group Tests - create load balancer',
@@ -118,7 +118,7 @@ class ServerGroupTestScenario(sk.SpinnakerTestScenario):
     builder = gcp.GceContractBuilder(self.gce_observer)
     (builder.new_clause_builder('Instance Created', retryable_for_secs=150)
      .list_resources('instance-groups')
-     .contains('name', self.__server_group_name))
+     .contains_path_value('name', self.__server_group_name))
 
     payload = self.agent.make_payload(
         job=job,
@@ -156,7 +156,7 @@ class ServerGroupTestScenario(sk.SpinnakerTestScenario):
      .inspect_resource('instance-groups',
                        self.__server_group_name,
                        ['--zone', self.TEST_ZONE])
-     .contains_eq('size', 2))
+     .contains_path_eq('size', 2))
 
     payload = self.agent.make_payload(
         job=job, description='Server Group Tests - resize to 2 instances',
@@ -203,7 +203,7 @@ class ServerGroupTestScenario(sk.SpinnakerTestScenario):
     builder = gcp.GceContractBuilder(self.gce_observer)
     (builder.new_clause_builder('Server Group Cloned', retryable_for_secs=90)
      .list_resources('managed-instance-groups')
-     .contains('baseInstanceName', self.__cloned_server_group_name))
+     .contains_path_value('baseInstanceName', self.__cloned_server_group_name))
 
     payload = self.agent.make_payload(
         job=job, description='Server Group Tests - clone server group',
@@ -231,8 +231,8 @@ class ServerGroupTestScenario(sk.SpinnakerTestScenario):
     builder = gcp.GceContractBuilder(self.gce_observer)
     (builder.new_clause_builder('Server Group Disabled', retryable_for_secs=90)
      .list_resources('managed-instance-groups')
-     .contains('baseInstanceName', self.__server_group_name)
-     .excludes_group([
+     .contains_path_value('baseInstanceName', self.__server_group_name)
+     .excludes_pred_list([
          jc.PathContainsPredicate('baseInstanceName', self.__server_group_name),
          jc.PathContainsPredicate('targetPools', 'https')]))
 
@@ -262,7 +262,7 @@ class ServerGroupTestScenario(sk.SpinnakerTestScenario):
     builder = gcp.GceContractBuilder(self.gce_observer)
     (builder.new_clause_builder('Server Group Enabled', retryable_for_secs=90)
      .list_resources('managed-instance-groups')
-     .contains_group([
+     .contains_pred_list([
          jc.PathContainsPredicate('baseInstanceName', self.__server_group_name),
          jc.PathContainsPredicate('targetPools', 'https')]))
 
@@ -293,7 +293,7 @@ class ServerGroupTestScenario(sk.SpinnakerTestScenario):
     builder = gcp.GceContractBuilder(self.gce_observer)
     (builder.new_clause_builder('Server Group Destroyed', retryable_for_secs=90)
      .list_resources('managed-instance-groups')
-     .excludes('baseInstanceName', serverGroupName))
+     .excludes_path_value('baseInstanceName', serverGroupName))
 
     payload = self.agent.make_payload(
         job=job, description='Server Group Tests - destroy server group',
@@ -319,7 +319,7 @@ class ServerGroupTestScenario(sk.SpinnakerTestScenario):
     builder = gcp.GceContractBuilder(self.gce_observer)
     (builder.new_clause_builder('Load Balancer Created', retryable_for_secs=30)
      .list_resources('forwarding-rules')
-     .excludes('name', self.__lb_name))
+     .excludes_path_value('name', self.__lb_name))
 
     payload = self.agent.make_payload(
         job=job, description='Server Group Tests - delete load balancer',

--- a/spinnaker/spinnaker_system/smoke_test.py
+++ b/spinnaker/spinnaker_system/smoke_test.py
@@ -171,18 +171,19 @@ class SmokeTestScenario(sk.SpinnakerTestScenario):
     (builder.new_clause_builder('Health Check Added',
                                 retryable_for_secs=30)
      .list_resources('http-health-checks')
-     .contains_group(
+     .contains_pred_list(
          [jc.PathContainsPredicate('name', '%s-hc' % load_balancer_name),
           jc.DICT_SUBSET(spec)]))
     (builder.new_clause_builder('Target Pool Added',
                                 retryable_for_secs=30)
      .list_resources('target-pools')
-     .contains('name', '%s-tp' % load_balancer_name))
+     .contains_path_value('name', '%s-tp' % load_balancer_name))
     (builder.new_clause_builder('Forwarding Rules Added',
                                 retryable_for_secs=30)
      .list_resources('forwarding-rules')
-     .contains_group([jc.PathContainsPredicate('name', load_balancer_name),
-                      jc.PathContainsPredicate('target', target_pool_name)]))
+     .contains_pred_list([
+          jc.PathContainsPredicate('name', load_balancer_name),
+          jc.PathContainsPredicate('target', target_pool_name)]))
 
     return st.OperationContract(
         self.new_post_operation(
@@ -216,13 +217,13 @@ class SmokeTestScenario(sk.SpinnakerTestScenario):
     builder = gcp.GceContractBuilder(self.gce_observer)
     (builder.new_clause_builder('Health Check Removed', retryable_for_secs=30)
      .list_resources('http-health-checks')
-     .excludes('name', '%s-hc' % load_balancer_name))
+     .excludes_path_value('name', '%s-hc' % load_balancer_name))
     (builder.new_clause_builder('TargetPool Removed')
      .list_resources('target-pools')
-     .excludes('name', '%s-tp' % load_balancer_name))
+     .excludes_path_value('name', '%s-tp' % load_balancer_name))
     (builder.new_clause_builder('Forwarding Rule Removed')
      .list_resources('forwarding-rules')
-     .excludes('name', load_balancer_name))
+     .excludes_path_value('name', load_balancer_name))
 
     return st.OperationContract(
         self.new_post_operation(
@@ -275,7 +276,7 @@ class SmokeTestScenario(sk.SpinnakerTestScenario):
     (builder.new_clause_builder('Managed Instance Group Added',
                                 retryable_for_secs=30)
      .inspect_resource('managed-instance-groups', group_name)
-     .contains_eq('targetSize', 2))
+     .contains_path_eq('targetSize', 2))
 
     return st.OperationContract(
         self.new_post_operation(
@@ -314,12 +315,12 @@ class SmokeTestScenario(sk.SpinnakerTestScenario):
     (builder.new_clause_builder('Managed Instance Group Removed')
      .inspect_resource('managed-instance-groups', group_name,
                        no_resource_ok=True)
-     .contains_eq('targetSize', 0))
+     .contains_path_eq('targetSize', 0))
 
     (builder.new_clause_builder('Instances Are Removed',
                                 retryable_for_secs=30)
      .list_resources('instances')
-     .excludes('name', group_name))
+     .excludes_path_value('name', group_name))
 
     return st.OperationContract(
         self.new_post_operation(

--- a/tests/gcp_testing/gce_contract_test.py
+++ b/tests/gcp_testing/gce_contract_test.py
@@ -45,7 +45,7 @@ class GceContractTest(unittest.TestCase):
     c1 = contract_builder.new_clause_builder('TITLE')
     extra_args=['arg1', 'arg2', 'arg3']
     verifier = c1.list_resources('instances', extra_args=extra_args)
-    verifier.contains('field', 'value')
+    verifier.contains_path_value('field', 'value')
 
     self.assertTrue(isinstance(verifier, jc.ValueObservationVerifierBuilder))
 
@@ -79,7 +79,7 @@ class GceContractTest(unittest.TestCase):
     c1 = contract_builder.new_clause_builder('TITLE')
     verifier = c1.inspect_resource(
         'instances', 'test_name', extra_args=extra_args, no_resource_ok=True)
-    verifier.contains('field', 'value')
+    verifier.contains_path_value('field', 'value')
 
     self.assertTrue(isinstance(verifier, jc.ValueObservationVerifierBuilder))
 

--- a/tests/json_contract/contract_test.py
+++ b/tests/json_contract/contract_test.py
@@ -163,7 +163,7 @@ class JsonContractTest(unittest.TestCase):
     # Non strict means some result should not contain B.
     builder = jc.ValueObservationVerifierBuilder(
         'Test Excludes', strict=strict)
-    builder.excludes(None, 'B')
+    builder.excludes_path_value(None, 'B')
 
     clause = jc.ContractClause('TestClause', fake_observer, builder.build())
     contract = jc.Contract()
@@ -192,7 +192,7 @@ class JsonContractTest(unittest.TestCase):
 
     eq_A_or_B = jc.OR([jc.STR_EQ('A'), jc.STR_EQ('B')])
     builder = jc.ValueObservationVerifierBuilder('Test Multiple')
-    builder.contains_pred(None, eq_A_or_B, min=2)
+    builder.contains_path_pred(None, eq_A_or_B, min=2)
 
     clause = jc.ContractClause('TestClause', fake_observer, builder.build())
     contract = jc.Contract()

--- a/tests/json_contract/value_observation_verifier_test.py
+++ b/tests/json_contract/value_observation_verifier_test.py
@@ -44,12 +44,12 @@ class JsonValueObservationVerifierTest(unittest.TestCase):
       self.assertEqual('TestAddConstraint', verifier.title)
       self.assertEqual([aA, bB], verifier.constraints)
 
-  def test_verifier_builder_contains_group(self):
+  def test_verifier_builder_contains_pred_list(self):
       aA = jc.PathPredicate('a', jc.STR_EQ('A'))
       bB = jc.PathPredicate('b', jc.STR_EQ('B'))
       builder = jc.ValueObservationVerifierBuilder('TestContainsGroup')
-      builder.contains_pred('a', jc.STR_EQ('A'))
-      builder.contains_pred('b', jc.STR_EQ('B'))
+      builder.contains_path_pred('a', jc.STR_EQ('A'))
+      builder.contains_path_pred('b', jc.STR_EQ('B'))
       verifier = builder.build()
 
       count_aA = jc.CardinalityPredicate(aA, 1, None)

--- a/tests/service_testing/testable_agent_test.py
+++ b/tests/service_testing/testable_agent_test.py
@@ -31,6 +31,10 @@ class FakeStatus(st.AgentOperationStatus):
   def finished(self):
     return self.__finished
 
+  @property
+  def finished_ok(self):
+     return self.__finished
+
   def __init__(self, operation):
     super(FakeStatus, self).__init__(operation)
     self.__finished = False


### PR DESCRIPTION
The names arent as concise, but might be easier to remember and distinguish.
  contains -> contains_path_value
  contains_eq -> contains_path_eq
  contains_pred -> contains_path_pred
  contains_group -> contains_pred_list
  excludes -> excludes_path_value
  excludes_eq -> excludes_path_eq
  excludes_pred -> excludes_path_pred
  excludes_group -> excludes_pred_list

These are still not ideal. "contains_path_value" and "contains_path_eq" sound
similar. contains_path_eq is looking for exact equality, and isnt that common
for us. The contains_path_value is really "contains a path whose value contains"
and is far more common because we dont know literal string choices and often
the value is composite and the test only cares about a subset of attributes.
I could call this "contains_path_subset" but "subset" isnt really the right
term for strings, which is very common.

@lwander 
