### PR TITLE
Renamed "TestableAgent" to BaseAgent

### DIFF
--- a/citest/aws_testing/aws_agent.py
+++ b/citest/aws_testing/aws_agent.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-"""Adapts citest TestableAgent to ineract with Amazon Web Services."""
+"""Adapts citest CliAgent to ineract with Amazon Web Services."""
 
 
 # Standard python modules.

--- a/citest/service_testing/__init__.py
+++ b/citest/service_testing/__init__.py
@@ -14,7 +14,7 @@
 
 """This package contains modules for testing services with citest.
 
-The testable_agent module provides an adapter for external system interactions
+The service_testing module provides an adapter for external system interactions
 as generic citest operations that can be controlled and reported using
 core citest components.
 
@@ -27,12 +27,12 @@ that interact with external systems using either HTTP messaging or
 invocation of command-line programs.
 """
 
-# The testable_agent module contains the base definitions.
-from testable_agent import(
+# The base_agent module contains the base definitions.
+from base_agent import(
     AgentError,
     AgentOperation,
     AgentOperationStatus,
-    TestableAgent)
+    BaseAgent)
 
 
 # The cli_agent module implements an agent that uses command-line programs.
@@ -70,7 +70,7 @@ from operation_contract import OperationContract
 # A NoOpOperation can be used to create a contract for an invariant.
 from nop_operation import NoOpOperation
 
-# The service_testing module adds support for writing tests with TestableAgent.
+# The service_testing module adds support for writing tests with BaseAgent.
 from agent_test_case import (
     AgentTestCase,
     AgentTestScenario)

--- a/citest/service_testing/agent_test_case.py
+++ b/citest/service_testing/agent_test_case.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 
-"""Specialization of base.BaseTestCase for testing with citest.TestableAgents.
+"""Specialization of base.BaseTestCase for testing with citest.BaseAgents.
 
-An AgentTestCase talks to both a TestableAgent and an external
+An AgentTestCase talks to both a BaseAgent and an external
 observer, it then uses data from the external observer to verify expectations
-made while talking to the TestableService.
+made while talking to the TestableSystem.
 
 The actual tests are written using operation_contract.OperationContract.
 Each OperationContract contains an AgentOperation, which is sent to the
-TestableAgent, and a Contract which specifies the expected system state
+BaseAgent, and a Contract which specifies the expected system state
 (resources it expects to find and/or resources it does not expect to find).
 
 A detailed log file is written as the test runs for more information.
@@ -242,7 +242,7 @@ class AgentTestScenario(object):
 
   @property
   def agent(self):
-    """The primary TestableAgent that is the focal point for the test."""
+    """The primary BaseAgent that is the focal point for the test."""
     return self.__agent
 
   @property
@@ -280,7 +280,7 @@ class AgentTestScenario(object):
           rather the scenarios may have a set of parameters that they use
           for their needs.
 
-      agent: [TestableAgent] Primary agent used in this scenario.
+      agent: [BaseAgent] Primary agent used in this scenario.
           If not prodided then construct a new one with the class new_agent
           factory method.
     """
@@ -333,8 +333,8 @@ class AgentTestCase(BaseTestCase):
     return ScenarioTestRunner.global_runner().scenario
 
   @property
-  def testable_agent(self):
-    """Return the primary TestableAgent for the current test scenario."""
+  def testing_agent(self):
+    """The BaseAgent for the current test scenario's testable system."""
     return self.scenario.agent
 
   def assertContract(self, contract):
@@ -494,7 +494,7 @@ class AgentTestCase(BaseTestCase):
       for i in range(max_tries):
         attempt_info = execution_trace.new_attempt()
         status = None
-        status = test_case.operation.execute(agent=self.testable_agent)
+        status = test_case.operation.execute(agent=self.testing_agent)
         status.wait(trace_every=full_trace)
 
         summary = status.error or ('Operation status OK' if status.finished_ok

--- a/citest/service_testing/base_agent.py
+++ b/citest/service_testing/base_agent.py
@@ -35,7 +35,7 @@ from ..base import JournalLogger
 
 
 class AgentError(Exception, JsonSnapshotable):
-  """Denotes an error reported by a TestableAgent."""
+  """Denotes an error reported by a BaseAgent."""
 
   def export_to_json_snapshot(self, snapshot, entity):
     """Implements JsonSnapshotable interface."""
@@ -52,11 +52,11 @@ class AgentError(Exception, JsonSnapshotable):
             and self.message == error.message)
 
 
-class TestableAgent(JsonSnapshotable):
+class BaseAgent(JsonSnapshotable):
   """Base class for adapting services and observers into the citest framework.
 
   The base class does not introduce any significant behavior, but the intent
-  of TestableAgent is to provide an adapter for interacting with the services
+  of BaseAgent is to provide an adapter for interacting with the services
   being tested, and (for convenience) the observers collecting observation
   data. The exact methods for doing this are introduced as the agents become
   specialized to the mechanism that will be needed and the particular APIs or
@@ -101,7 +101,7 @@ class TestableAgent(JsonSnapshotable):
 class AgentOperationStatus(JsonSnapshotable):
   """Base class for current Status on AgentOperation.
 
-  The operations performed by testable agents have disparate results depending
+  The operations performed by base agents have disparate results depending
   on the underlying service in question. Besides the data types being
   different, the protocols are as well. Often services are asynchronous,
   returning a handle used to query for current status information. This
@@ -166,7 +166,7 @@ class AgentOperationStatus(JsonSnapshotable):
 
   @property
   def agent(self):
-    """A reference to the TestableAgent that executed the |operation|."""
+    """A reference to the BaseAgent that executed the |operation|."""
     return self.__operation.agent
 
   def export_to_json_snapshot(self, snapshot, entity):
@@ -296,7 +296,7 @@ class AgentOperation(JsonSnapshotable):
   """
   @property
   def agent(self):
-    """The TestableAgent to execute the operation.
+    """The BaseAgent to execute the operation.
 
     This may be None if the binding is deferred. However, it must be bound
     before it is executed.
@@ -321,7 +321,7 @@ class AgentOperation(JsonSnapshotable):
     """Binds the agent to the operation.
 
     Args:
-      agent: [TestableAgent] If None then unbind.
+      agent: [BaseAgent] If None then unbind.
     """
     if self.__agent:
       logging.getLogger(__name__).warning('Rebinding agent on ' + str(self))
@@ -332,7 +332,7 @@ class AgentOperation(JsonSnapshotable):
 
     Args:
       title: [string] The name of the operation for reporting purposes only.
-      agent: [TestableAgent] The agent performing the operation can be bound
+      agent: [BaseAgent] The agent performing the operation can be bound
           later, but must eventually be bound.
     """
     self.__title = title
@@ -353,7 +353,7 @@ class AgentOperation(JsonSnapshotable):
     This method must be specialized.
 
     Args:
-      agent: [TestableAgent] If provided, use instead of the one bound.
+      agent: [BaseAgent] If provided, use instead of the one bound.
 
     Returns:
       OperationStatus for this invocation.

--- a/citest/service_testing/cli_agent.py
+++ b/citest/service_testing/cli_agent.py
@@ -20,7 +20,7 @@ import subprocess
 from ..base import JournalLogger
 from ..base import JsonSnapshotable
 from .. import json_contract as jc
-from . import testable_agent
+from . import base_agent
 
 
 class CliResponseType(collections.namedtuple('CliResponseType',
@@ -47,11 +47,11 @@ class CliResponseType(collections.namedtuple('CliResponseType',
       builder.make_output(entity, 'stdout', self.output, format='json')
 
 
-class CliRunStatus(testable_agent.AgentOperationStatus):
+class CliRunStatus(base_agent.AgentOperationStatus):
   """Concrete specialization of AgentOperationStatus for CliAgent operations.
 
   Attributes:
-    See testable_agent.AgentOperationStatus.
+    See base_agent.AgentOperationStatus.
   """
   @property
   def finished(self):
@@ -87,7 +87,7 @@ class CliRunStatus(testable_agent.AgentOperationStatus):
     self.__cli_response = cli_response
 
 
-class CliAgentRunError(testable_agent.AgentError):
+class CliAgentRunError(base_agent.AgentError):
   """An error for reporting execution failures.
 
   Properties:
@@ -122,8 +122,8 @@ class CliAgentRunError(testable_agent.AgentError):
     return re.search(regex, self.__run_response.error, re.MULTILINE)
 
 
-class CliAgent(testable_agent.TestableAgent):
-  """A specialization of TestableAgent for invoking command-line programs."""
+class CliAgent(base_agent.BaseAgent):
+  """A specialization of BaseAgent for invoking command-line programs."""
 
   def __init__(self, program, output_scrubber=None):
     """Standard constructor.
@@ -206,7 +206,7 @@ class CliAgent(testable_agent.TestableAgent):
     return CliResponseType(code, stdout, stderr)
 
 
-class CliRunOperation(testable_agent.AgentOperation):
+class CliRunOperation(base_agent.AgentOperation):
   """Specialization of AgentOperation that invokes a program."""
   def __init__(self, title, args, cli_agent=None):
     super(CliRunOperation, self).__init__(title, cli_agent)

--- a/citest/service_testing/http_agent.py
+++ b/citest/service_testing/http_agent.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-"""Provides base support for TestableAgents based on HTTP interactions."""
+"""Provides base support for BaseAgents based on HTTP interactions."""
 
 import base64
 import collections
@@ -26,7 +26,7 @@ from ..base import JournalLogger
 from ..base import JsonSnapshotable
 from .http_scrubber import HttpScrubber
 
-from . import testable_agent
+from . import base_agent
 
 
 class HttpResponseType(collections.namedtuple('HttpResponseType',
@@ -85,7 +85,7 @@ class HttpResponseType(collections.namedtuple('HttpResponseType',
           code=self.retcode, body=self.error or self.output))
 
 
-class HttpOperationStatus(testable_agent.AgentOperationStatus):
+class HttpOperationStatus(base_agent.AgentOperationStatus):
   """Specialization of AgentOperationStatus for HttpAgent operations.
 
   This class assumes generic synchronous HTTP requests. Services may
@@ -166,8 +166,8 @@ class SynchronousHttpOperationStatus(HttpOperationStatus):
     return False
 
 
-class HttpAgent(testable_agent.TestableAgent):
-  """A specialization of TestableAgent for interacting with HTTP services."""
+class HttpAgent(base_agent.BaseAgent):
+  """A specialization of BaseAgent for interacting with HTTP services."""
 
   @property
   def headers(self):
@@ -374,7 +374,7 @@ class HttpAgent(testable_agent.TestableAgent):
     return self.__send_http_request(path, 'GET', trace=trace)
 
 
-class BaseHttpOperation(testable_agent.AgentOperation):
+class BaseHttpOperation(base_agent.AgentOperation):
   """Specialization of AgentOperation that performs HTTP POST."""
   @property
   def path(self):

--- a/citest/service_testing/nop_operation.py
+++ b/citest/service_testing/nop_operation.py
@@ -14,10 +14,10 @@
 
 """A no-op operation does nothing. It is intended for observing invariants."""
 
-import testable_agent
+import base_agent
 
 
-class ConstantOperationStatus(testable_agent.AgentOperationStatus):
+class ConstantOperationStatus(base_agent.AgentOperationStatus):
   """An operation status meant for a NoOp operation.
 
   By default this is simply success. It could be configured to be an error.
@@ -58,7 +58,7 @@ class ConstantOperationStatus(testable_agent.AgentOperationStatus):
     self.__error = error
 
 
-class NoOpOperation(testable_agent.AgentOperation):
+class NoOpOperation(base_agent.AgentOperation):
   """Implements an operation that succeeds without doing anything.
 
   This is intended to test invariants as a contract. The invariant is

--- a/citest/service_testing/operation_contract.py
+++ b/citest/service_testing/operation_contract.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-"""Specifies test cases using TestableAgents."""
+"""Specifies test cases using BaseAgents."""
 
 from ..base import JsonSnapshotable
 
@@ -21,7 +21,7 @@ from ..base import JsonSnapshotable
 class OperationContract(JsonSnapshotable):
   """Specifies a testable operation and contract to verify it.
 
-  This is essentially a "test case" using  TestableAgents.
+  This is essentially a "test case" using  BaseAgents.
   """
   @property
   def title(self):

--- a/spinnaker/spinnaker_system/aws_kato_test.py
+++ b/spinnaker/spinnaker_system/aws_kato_test.py
@@ -92,7 +92,7 @@ class AwsKatoTestScenario(sk.SpinnakerTestScenario):
         like additional custom bindings it could add them to initArgumentParser.
 
     Returns:
-      A citest.service_testing.TestableAgent that can interact with Kato.
+      A citest.service_testing.BaseAgent that can interact with Kato.
       This is the agent that test operations will be posted to.
     """
     return kato.new_agent(bindings)

--- a/spinnaker/spinnaker_system/kato_test.py
+++ b/spinnaker/spinnaker_system/kato_test.py
@@ -86,7 +86,7 @@ class KatoTestScenario(sk.SpinnakerTestScenario):
         like additional custom bindings it could add them to initArgumentParser.
 
     Returns:
-      A citest.service_testing.TestableAgent that can interact with Kato.
+      A citest.service_testing.BaseAgent that can interact with Kato.
       This is the agent that test operations will be posted to.
     """
     return kato.new_agent(bindings)

--- a/spinnaker/spinnaker_system/server_group_tests.py
+++ b/spinnaker/spinnaker_system/server_group_tests.py
@@ -26,7 +26,7 @@ class ServerGroupTestScenario(sk.SpinnakerTestScenario):
         like additional custom bindings it could add them to initArgumentParser.
 
     Returns:
-      A citest.service_testing.TestableAgent that can interact with Gate.
+      A citest.service_testing.BaseAgent that can interact with Gate.
       This is the agent that test operations will be posted to.
     '''
     return gate.new_agent(bindings)

--- a/spinnaker/spinnaker_testing/jenkins_agent.py
+++ b/spinnaker/spinnaker_testing/jenkins_agent.py
@@ -15,10 +15,10 @@
 
 import os
 
-from citest.service_testing import (testable_agent, http_agent)
+from citest.service_testing import (base_agent, http_agent)
 
 
-class JenkinsOperationStatus(testable_agent.AgentOperationStatus):
+class JenkinsOperationStatus(base_agent.AgentOperationStatus):
   """Specialization of AgentOperationStatus for Jenkins operations.
 
   Jenkins operations are interesting to the effect that we use them to
@@ -91,8 +91,8 @@ class JenkinsOperationStatus(testable_agent.AgentOperationStatus):
         snapshot, entity)
 
 
-class JenkinsAgent(testable_agent.TestableAgent):
-  """A specialization of TestableAgent for interacting with Jenkins."""
+class JenkinsAgent(base_agent.BaseAgent):
+  """A specialization of BaseAgent for interacting with Jenkins."""
   def __init__(self, baseUrl, auth_path, owner_agent):
     super(JenkinsAgent, self).__init__()
     self.__http_agent = http_agent.HttpAgent(baseUrl)
@@ -159,7 +159,7 @@ class JenkinsAgent(testable_agent.TestableAgent):
         status_path=status_path)
 
 
-class BaseJenkinsOperation(testable_agent.AgentOperation):
+class BaseJenkinsOperation(base_agent.AgentOperation):
   @property
   def status_class(self):
     return self.__status_class

--- a/spinnaker/spinnaker_testing/spinnaker.py
+++ b/spinnaker/spinnaker_testing/spinnaker.py
@@ -232,7 +232,7 @@ class SpinnakerStatus(service_testing.HttpOperationStatus):
 
 
 class SpinnakerAgent(service_testing.HttpAgent):
-  """A TestableAgent  to a spinnaker subsystem.
+  """A BaseAgent  to a spinnaker subsystem.
 
   The agent supports POST using the standard spinnaker subsystem protocol
   of returning status references and obtaining details through followup GETs.

--- a/tests/service_testing/base_agent_test.py
+++ b/tests/service_testing/base_agent_test.py
@@ -17,7 +17,7 @@ import unittest
 import citest.service_testing as st
 
 
-class FakeAgent(st.TestableAgent):
+class FakeAgent(st.BaseAgent):
    def __init__(self):
      super(FakeAgent, self).__init__()
 
@@ -60,7 +60,7 @@ class FakeStatus(st.AgentOperationStatus):
         self.__finished = True
 
 
-class TestableAgentTest(unittest.TestCase):
+class BaseAgentTest(unittest.TestCase):
   def test_operation_constructor(self):
     operation = st.AgentOperation('TestStatus')
     self.assertEqual('TestStatus', operation.title)
@@ -217,5 +217,5 @@ class TestableAgentTest(unittest.TestCase):
 
 if __name__ == '__main__':
   loader = unittest.TestLoader()
-  suite = loader.loadTestsFromTestCase(TestableAgentTest)
+  suite = loader.loadTestsFromTestCase(BaseAgentTest)
   unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
The BaseAgent is used for a "Testing Agent" role and an "Observation Agent"
role. Calling it TestableAgent leads to confusion.

The testable_agent attribute is now testing_agent attribute.
@lwander 
