### PR TITLE
Changed HttpResponseType attr semantics. Renamed Cli/HttpResponseType…

### DIFF
--- a/citest/aws_testing/aws_agent.py
+++ b/citest/aws_testing/aws_agent.py
@@ -105,7 +105,7 @@ class AwsAgent(st.CliAgent):
       List of objects from the command.
     """
     aws_response = self.run(command_args, trace)
-    if aws_response.retcode != 0:
+    if not aws_response.ok():
       raise ValueError(aws_response.error)
 
     decoder = json.JSONDecoder()

--- a/citest/aws_testing/aws_contract.py
+++ b/citest/aws_testing/aws_contract.py
@@ -40,7 +40,7 @@ class AwsObjectObserver(jc.ObjectObserver):
 
   def collect_observation(self, observation, trace=True):
     aws_response = self.__aws.run(self.__args, trace)
-    if aws_response.retcode != 0:
+    if not aws_response.ok():
       observation.add_error(
           cli_agent.CliAgentRunError(self.__aws, aws_response))
       return []

--- a/citest/gcp_testing/gce_contract.py
+++ b/citest/gcp_testing/gce_contract.py
@@ -48,7 +48,7 @@ class GCloudObjectObserver(jc.ObjectObserver):
 
   def collect_observation(self, observation, trace=True):
     gcloud_response = self.__gcloud.run(self.__args, trace=trace)
-    if gcloud_response.retcode != 0:
+    if not gcloud_response.ok():
       observation.add_error(
           cli_agent.CliAgentRunError(self.__gcloud, gcloud_response))
       return []

--- a/citest/gcp_testing/gce_util.py
+++ b/citest/gcp_testing/gce_util.py
@@ -170,7 +170,7 @@ def _network_interfaces_for_instance(gcloud, instance):
   logger = logging.getLogger(__name__)
   logger.debug('Testing locating test project instance=%s', instance)
   gcloud_response = gcloud.describe_resource('instances', instance)
-  if gcloud_response.retcode != 0:
+  if not gcloud_response.ok():
     logger.error(
         'Could not find instance=%s in project=%s, zone=%s: %s',
         instance, gcloud.project, gcloud.zone, gcloud_response.error)

--- a/citest/gcp_testing/gcloud_agent.py
+++ b/citest/gcp_testing/gcloud_agent.py
@@ -312,10 +312,10 @@ class GCloudAgent(cli_agent.CliAgent):
         instance, ['--command', '"%s"' % escaped_command], async=False)
     output = PassphraseInjector(
         fd=fd, ssh_passphrase_file=self.__ssh_passphrase_file)()
-    retcode = os.waitpid(pid, os.WNOHANG)[1]
-    if not retcode:
+    exit_code = os.waitpid(pid, os.WNOHANG)[1]
+    if not exit_code:
       return cli_agent.CliResponseType(0, output, '')
-    return cli_agent.CliResponseType(retcode, '', output)
+    return cli_agent.CliResponseType(exit_code, '', output)
 
   def list_resources(self, gce_type, format='json', extra_args=None):
     """Obtain a list of references to all the GCE resources of a given type.

--- a/citest/service_testing/cli_agent.py
+++ b/citest/service_testing/cli_agent.py
@@ -24,23 +24,27 @@ from . import base_agent
 
 
 class CliResponseType(collections.namedtuple('CliResponseType',
-                                             ['retcode', 'output', 'error']),
+                                             ['exit_code', 'output', 'error']),
                       JsonSnapshotable):
   """Holds the results from running the command-line program.
 
   Attributes:
-    retcode: The program exit code.
+    exit_code: The program exit code.
     output: The program stdout.
     error: The program stderr (or other error explaining failure to run).
   """
+  def ok(self):
+    """Returns True if the call succeeded, False otherwise."""
+    return self.exit_code == 0
+
   def __str__(self):
-    return 'retcode={0} output={1!r} error={2!r}'.format(
-        self.retcode, self.output, self.error)
+    return 'exit_code={0} output={1!r} error={2!r}'.format(
+        self.exit_code, self.output, self.error)
 
   def export_to_json_snapshot(self, snapshot, entity):
     """Implements JsonSnapshotable interface."""
     builder = snapshot.edge_builder
-    builder.make(entity, 'Exit Code', self.retcode)
+    builder.make(entity, 'Exit Code', self.exit_code)
     if self.error:
       builder.make_error(entity, 'stderr', self.error, format='json')
     if self.output:
@@ -59,7 +63,7 @@ class CliRunStatus(base_agent.AgentOperationStatus):
 
   @property
   def finished_ok(self):
-    return self.__cli_response.retcode == 0
+    return self.__cli_response.ok()
 
   @property
   def timed_out(self):

--- a/citest/service_testing/http_observer.py
+++ b/citest/service_testing/http_observer.py
@@ -58,7 +58,7 @@ class HttpObjectObserver(jc.ObjectObserver):
     # collect some thing out of the results.
     result = self.agent.get(self.__path, trace=trace)
     if not result.ok():
-      error = 'Observation failed with HTTP %d.\n%s' % (result.retcode,
+      error = 'Observation failed with HTTP %s.\n%s' % (result.http_code,
                                                         result.error)
       logging.getLogger(__name__).error(error)
       observation.add_error(AgentError(error))

--- a/spinnaker/spinnaker_system/kato_test.py
+++ b/spinnaker/spinnaker_system/kato_test.py
@@ -547,7 +547,7 @@ class KatoTestScenario(sk.SpinnakerTestScenario):
     logger.debug('Looking up available images.')
     cli_result = gcloud_agent.list_resources('images', extra_args=extra_args)
 
-    if cli_result.retcode != 0:
+    if not cli_result.ok():
       raise RuntimeError('GCloud failed with: {0}'.format(str(cli_result)))
     json_doc = json_module.JSONDecoder().decode(cli_result.output)
 

--- a/spinnaker/spinnaker_testing/gate.py
+++ b/spinnaker/spinnaker_testing/gate.py
@@ -63,6 +63,11 @@ class GateTaskStatus(sk.SpinnakerStatus):
     """
     super(GateTaskStatus, self).__init__(operation, original_response)
 
+    if not original_response.ok():
+      self._bind_error(original_response.error_message)
+      self.current_state = 'HTTP_ERROR'
+      return
+
     doc = None
     try:
       doc = json.JSONDecoder().decode(original_response.output)

--- a/spinnaker/spinnaker_testing/jenkins_agent.py
+++ b/spinnaker/spinnaker_testing/jenkins_agent.py
@@ -46,7 +46,7 @@ class JenkinsOperationStatus(base_agent.AgentOperationStatus):
 
   @property
   def error(self):
-    return self.__trigger_status.error
+    return self.__trigger_status.error_message
 
   @property
   def status_agent(self):

--- a/spinnaker/spinnaker_testing/kato.py
+++ b/spinnaker/spinnaker_testing/kato.py
@@ -59,6 +59,11 @@ class _KatoStatus(sk.SpinnakerStatus):
     """
     super(_KatoStatus, self).__init__(operation, original_response)
 
+    if not original_response.ok():
+      self.__finished = True
+      self.__failed = True
+      return
+
     self.__finished = False
     self.__failed = False
 

--- a/spinnaker/spinnaker_testing/spinnaker.py
+++ b/spinnaker/spinnaker_testing/spinnaker.py
@@ -172,7 +172,7 @@ class SpinnakerStatus(service_testing.HttpOperationStatus):
     self.__error = None
     self.__json_doc = None
 
-    if not original_response or original_response.retcode < 0:
+    if not original_response or original_response.http_code is None:
       self.__current_state = 'REQUEST_FAILED'
       return
 
@@ -211,7 +211,7 @@ class SpinnakerStatus(service_testing.HttpOperationStatus):
       http_response: [HttpResponseType] From the last status update.
     """
     # super(SpinnakerStatus, self).set_http_response(http_response)
-    if http_response.retcode < 0:
+    if http_response.http_code is None:
       self.__current_state = 'Unknown'
       return
 
@@ -473,7 +473,7 @@ class SpinnakerAgent(service_testing.HttpAgent):
         # We need to base64 the binary results so we return text.
         '; (sudo tar czf - $LIST 2> /dev/null | base64)')
 
-    if response.retcode != 0:
+    if not response.ok():
       logger.error(
           'Could not determine configuration:\n%s', response.error)
       return None


### PR DESCRIPTION
… attrs.

CliResponseType.retcode -> CliResponseType.exit_code
HttpResponseType.retcode -> HttpResponseType.http_code
HttpResponseType.error -> HttpResponseType.execption

Before HttpResponseType set output only on success and error only on errors.
Now output is always the HTTP response. Exception is an exception for
anything else where there is not an HTTP response. Rather than setting
retcode = -1 on error, http_code is None on exception.

Added HttpResponseType.error_message attribute which is a string form of
the error (either HTTP response error or exception) to provide the convienence
that the old "error" attribute semantics provided.

Added CliResponseType.ok() for clarity rather than checking the exit_code
for 0.

@lwander 
