### PR TITLE
Update bake_and_deploy_test.py

### DIFF
--- a/spinnaker/spinnaker_system/bake_and_deploy_test.py
+++ b/spinnaker/spinnaker_system/bake_and_deploy_test.py
@@ -70,11 +70,12 @@
 #     python $CITEST_ROOT/spinnaker/spinnaker_system/bake_and_deploy_test.py \
 #     --native_hostname=host-running-smoke-test
 #     --managed_gce_project=$PROJECT \
-#     --test_gce_zone=$ZONE
+#     --test_gce_zone=$ZONE \
+#     --test_aws_region=$AWS_REGION \
 #     --jenkins_url=$JENKINS_URL \
 #     --jenkins_auth_path=$JENKINS_AUTH_PATH \
 #     --jenkins_job=$JENKINS_JOB \
-#     --jenkins_token=$JENKINS_TOKEN
+#     --jenkins_token=$JENKINS_TOKE \
 #     --test_google \
 #     --test_aws
 

--- a/spinnaker/spinnaker_system/bake_and_deploy_test.py
+++ b/spinnaker/spinnaker_system/bake_and_deploy_test.py
@@ -75,7 +75,7 @@
 #     --jenkins_url=$JENKINS_URL \
 #     --jenkins_auth_path=$JENKINS_AUTH_PATH \
 #     --jenkins_job=$JENKINS_JOB \
-#     --jenkins_token=$JENKINS_TOKE \
+#     --jenkins_token=$JENKINS_TOKEN \
 #     --test_google \
 #     --test_aws
 


### PR DESCRIPTION
`test_aws_region` parameter was missing in our test, so I'm updating the sample command here to make it clear that it's needed.

@ewiseblatt