### PR TITLE
Sorts GCE images for comparison

### DIFF
--- a/spinnaker/spinnaker_system/google_kato_test.py
+++ b/spinnaker/spinnaker_system/google_kato_test.py
@@ -559,6 +559,7 @@ class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
     logger.debug('Configured with Spinnaker account "%s"', spinnaker_account)
     expect_images = [{'account': spinnaker_account, 'imageName': image['name']}
                      for image in json_doc]
+    expect_images = sorted(expect_images, key=lambda k: k['imageName'])
 
     # pylint: disable=bad-continuation
     builder = HttpContractBuilder(self.agent)


### PR DESCRIPTION
With the redis based impl, image keys get pulled out in a random order. I changed the image controller to sort the output in https://github.com/spinnaker/clouddriver/pull/478 and this PR matches that.

@duftler @ewiseblatt PTAL. 
