### PR TITLE
Refactored observers, verifiers, and contracts.

### DIFF
--- a/citest/json_contract/contract.py
+++ b/citest/json_contract/contract.py
@@ -28,7 +28,7 @@ import time
 
 from ..base import JournalLogger
 from ..base import JsonSnapshotable
-from . import predicate
+from ..json_predicate import predicate
 from . import observer as ob
 from . import observation_verifier as ov
 
@@ -82,6 +82,11 @@ class ContractClauseVerifyResult(predicate.PredicateResult):
         self.__clause.title,
         self.__verify_results.enumerated_summary_message)
 
+  def __repr__(self):
+    return '{0!r} clause={1!r} verify_results={2!r}'.format(
+        super(ContractClauseVerifyResult, self).__repr__(),
+        self.__clause, self.__verify_results)
+
   def export_to_json_snapshot(self, snapshot, entity):
     """Implements JsonSnapshotable interface."""
     builder = snapshot.edge_builder
@@ -113,7 +118,11 @@ class ContractClause(predicate.ValuePredicate):
     return self.__title
 
   def __str__(self):
-    return 'Clause {0}  verifier={1}'.format(self.__title, self._verifier)
+    return 'Clause {0}  verifier={1}'.format(self.__title, self.__verifier)
+
+  def __repr__(self):
+    return '{0}  title={1} verifier={2!r}'.format(
+        super(ContractClause, self).__repr__(), self.__title, self.__verifier)
 
   def export_to_json_snapshot(self, snapshot, entity):
     """Implements JsonSnapshotable interface."""
@@ -284,6 +293,9 @@ class ContractClauseBuilder(object):
     self.__verifier_builder = (verifier_builder
                                or ov.ObservationVerifierBuilder(title))
     self.__retryable_for_secs = retryable_for_secs
+    if strict:
+      logger = logging.getLogger(__name__)
+      logger.warning('Strict flag is DEPRECATED in {0}'.format(title))
 
   def build(self):
     """Build the clause from the builder specification."""
@@ -329,6 +341,10 @@ class ContractVerifyResult(predicate.PredicateResult):
         str_ok,
         '\n'.join(
             [c.enumerated_summary_message for c in self.__clause_results]))
+
+  def __repr__(self):
+    return '{0} clause_results={1!r}'.format(
+        super(ContractVerifyResult, self).__repr__(), self.__clause_results)
 
   def export_to_json_snapshot(self, snapshot, entity):
     """Implements JsonSnapshotable interface."""

--- a/citest/json_contract/observation_failure.py
+++ b/citest/json_contract/observation_failure.py
@@ -15,10 +15,10 @@
 
 """Support for notifying and detecting failures in observers."""
 
+from ..json_predicate import map_predicate
+from ..json_predicate import predicate
 from . import observation_verifier as ov
 from . import observer
-from . import map_predicate
-from . import predicate
 
 
 class ObservationFailedError(predicate.PredicateResult):
@@ -106,6 +106,5 @@ class ObservationFailureVerifier(ov.ObservationVerifier):
 
     return ov.ObservationVerifyResult(
         valid=valid, observation=observation,
-        all_results=[result],
         good_results=good_results, bad_results=bad_results,
         failed_constraints=[], comment=comment)

--- a/citest/json_contract/observer.py
+++ b/citest/json_contract/observer.py
@@ -108,8 +108,7 @@ class Observation(JsonSnapshotable):
    """
     if len(list_a) != len(list_b):
       return False
-    for i in range(len(list_a)):
-      error_a = list_a[i]
+    for i, error_a in enumerate(list_a):
       error_b = list_b[i]
       if isinstance(error_a, Exception):
         if error_a.__class__ != error_b.__class__:

--- a/citest/json_contract/value_observation_verifier.py
+++ b/citest/json_contract/value_observation_verifier.py
@@ -14,33 +14,44 @@
 
 import logging
 
-from . import binary_predicate
-from . import cardinality_predicate
-from . import logic_predicate
-from . import map_predicate
+from ..json_predicate import binary_predicate
+from ..json_predicate import cardinality_predicate
+from ..json_predicate import logic_predicate
+from ..json_predicate import path_predicate
+from ..json_predicate import predicate
 from . import observation_verifier as ov
 from . import observation_failure as of
-from . import path_predicate
-from . import predicate
 
 
 class ValueObservationVerifierBuilder(ov.ObservationVerifierBuilder):
   def __init__(self, title, strict=False):
+    """Constructor.
+
+    Args:
+      title: [string] The name of the verifier for reporting purposes.
+      strict: [bool] Whether the verifier is strict or not.
+         Strict verifiers require all the objects to satisfy all the
+         constraints.  Non-strict verifiers require all the constraints
+         to be satisfied by at least one object (but not necessarily the same),
+         and some objects may not satisfy any constraints at all.
+    """
     super(ValueObservationVerifierBuilder, self).__init__(title)
     self.__strict = strict
     self.__constraints = []
 
   def __eq__(self, builder):
+    """Specializes interface."""
     return (super(ValueObservationVerifierBuilder, self).__eq__(builder)
             and self.__strict == builder.__strict
             and self.__constraints == builder.__constraints)
 
   def _do_build_generate(self, dnf_verifiers):
-      return ValueObservationVerifier(
-          title=self.title,
-          dnf_verifiers=dnf_verifiers,
-          unmapped_constraints=self.__constraints,
-          strict=self.__strict)
+    """Constructs the actual instance."""
+    return ValueObservationVerifier(
+        title=self.title,
+        dnf_verifiers=dnf_verifiers,
+        constraints=self.__constraints,
+        strict=self.__strict)
 
   def export_to_json_snapshot(self, snapshot, entity):
     """Implements JsonSnapshotable interface."""
@@ -48,12 +59,12 @@ class ValueObservationVerifierBuilder(ov.ObservationVerifierBuilder):
     if len(self.__constraints) == 1:
       # Optimize model for single-element list
       snapshot.edge_builder.make_control(
-        entity, 'Constraint', self.__constraints[0])
+          entity, 'Constraint', self.__constraints[0])
     else:
       snapshot.edge_builder.make_control(
-        entity, 'Constraints', self.__constraints)
+          entity, 'Constraints', self.__constraints)
 
-    super(ValueObserverVerifierBuilder, self).export_to_json_snapshot(
+    super(ValueObservationVerifierBuilder, self).export_to_json_snapshot(
         snapshot, entity)
 
   def add_constraint(self, constraint):
@@ -61,12 +72,6 @@ class ValueObservationVerifierBuilder(ov.ObservationVerifierBuilder):
       raise TypeError('{0} is not predicate.ValuePredicate'.format(
           constraint.__class__))
     self.__constraints.append(constraint)
-    return self
-
-  def add_mapped_constraint(self, constraint, min=1, max=None):
-    pred = map_predicate.MapPredicate(pred=constraint, min=min, max=max)
-    self.__constraints.append(
-        map_predicate.MapPredicate(pred=constraint, min=min, max=max))
     return self
 
   def contains_path_value(self, path, value, min=1, max=None):
@@ -79,8 +84,8 @@ class ValueObservationVerifierBuilder(ov.ObservationVerifierBuilder):
 
   def contains_path_pred(self, path, pred, min=1, max=None):
     self.add_constraint(
-      cardinality_predicate.CardinalityPredicate(
-          path_predicate.PathPredicate(path, pred), min=min, max=max))
+        cardinality_predicate.CardinalityPredicate(
+            path_predicate.PathPredicate(path, pred), min=min, max=max))
     return self
 
   def contains_pred_list(self, pred_list, min=1, max=None):
@@ -97,7 +102,8 @@ class ValueObservationVerifierBuilder(ov.ObservationVerifierBuilder):
     return self
 
   def excludes_path_value(self, path, value, max=0):
-    return self.excludes_path_pred(path, binary_predicate.CONTAINS(value), max)
+    return self.excludes_path_pred(path, binary_predicate.CONTAINS(value),
+                                   max)
 
   def excludes_path_eq(self, path, value, max=0):
     return self.excludes_path_pred(
@@ -136,8 +142,7 @@ class ValueObservationVerifier(ov.ObservationVerifier):
 
   def __init__(self,
                title, dnf_verifiers=None,
-               mapped_constraints=None,
-               unmapped_constraints=None,
+               constraints=None,
                strict=False):
     """Construct instance.
 
@@ -146,10 +151,8 @@ class ValueObservationVerifier(ov.ObservationVerifier):
       dnf_verifiers: A list of lists of jc.ObservationVerifier where the outer
           list are OR'd together and the inner lists are AND'd together
           (i.e. disjunctive normal form).
-      unmapped_constraints: A list of jc.ValuePredicate to apply to the
+      constraints: A list of jc.ValuePredicate to apply to the
           observation object list.
-      mapped_constraints: A list of jc.ValuePredicate to apply to the
-          individual objects within the observation object list.
       strict: If True then the verifier requires all the observed elements to
           satisfy all the constraints (including future added constraints).
           Otherwise if False then the verifier requires each of the constraints
@@ -158,20 +161,17 @@ class ValueObservationVerifier(ov.ObservationVerifier):
     """
     super(ValueObservationVerifier, self).__init__(title, dnf_verifiers)
     self.__strict = strict
-    self.__constraints = []
-    if unmapped_constraints:
-      self.__constraints.extend(unmapped_constraints)
-    for c in mapped_constraints or []:
-      self.__constraints.append(map_predicate.MapPredicate(c))
+    self.__constraints = constraints
 
   def __call__(self, observation):
     if observation.errors:
       logging.getLogger(__name__).debug(
-        'Failing because of observation errors %s', observation.errors)
+          'Failing because of observation errors %s', observation.errors)
       return ov.ObservationVerifyResult(
           valid=False, observation=observation,
-          all_results=[of.ObservationFailedError(observation.errors)],
-          good_results=[], bad_results=[], failed_constraints=[],
+          good_results=[],
+          bad_results=[of.ObservationFailedError(observation.errors)],
+          failed_constraints=[],
           comment='Observation Failed.')
 
     all_objects = observation.objects
@@ -187,46 +187,35 @@ class ValueObservationVerifier(ov.ObservationVerifier):
       object_list = all_objects
 
     # Every constraint must be satisfied by at least one object.
-    # If strict then every object must be verified by at least one constraint.
+    # If strict then every object must be verified by at least one
+    # constraint.
     valid = True
     final_builder = ov.ObservationVerifyResultBuilder(observation)
 
     for constraint in self.__constraints:
-      logging.getLogger(__name__).debug('Verifying constraint=%s', constraint)
-      constraint_result = constraint(object_list)
+      logging.getLogger(__name__).debug('Verifying constraint=%s',
+                                        constraint)
 
+      if isinstance(constraint, path_predicate.ProducesPathPredicateResult):
+        constraint_result = constraint(object_list)
+      else:
+        constraint_result = (
+            path_predicate.PathPredicate('', constraint)(object_list))
       if not constraint_result:
+        final_builder.add_failed_constraint(constraint)
         logging.getLogger(__name__).debug('FAILED constraint')
         valid = False
 
-      # This is messy. On one hand we may want to have mapped results
-      # to show which objects are valid or not if we are looking individually.
-      # But on the other hand, we might be looking at all the objects as a
-      # collection in whole (e.g. cardinality). Really we should not be
-      # assuming a map predicate result, but currently are. So we're going
-      # to coerce non-map results into map results.
-      # TODO(ewiseblatt): Fix this by refactoring this and its base class.
-      skip_strict = True
-      if isinstance(constraint_result, map_predicate.MapPredicateResult):
-          # If we didnt map anything, then the strict check isnt appropriate.
-          skip_strict = False
-      else:
-          map_result_builder = map_predicate.MapPredicateResultBuilder(
-              constraint)
-          map_result_builder.add_result([object_list], constraint_result)
-          constraint_result = map_result_builder.build(constraint_result.valid)
-          if constraint_result.valid:
-            skip_strict = True
-      final_builder.add_map_result(constraint_result)
+      final_builder.add_path_predicate_result(constraint_result)
 
-    if valid and self.__strict and not skip_strict:
+    if valid and self.__strict:
       len_validated = len(final_builder.validated_object_set)
       len_objects = len(object_list)
       valid = len_validated == len_objects
 
       if not valid:
-        logging.getLogger(__name__).error(
-          'Strict verifier "%s" only confirmed %d of %d objects.',
-          self.title, len_validated, len_objects)
+        comment = ('Strict verifier "{0}" confirmed {1} of {2} objects.'
+                   .format(self.title, len_validated, len_objects))
+        logging.getLogger(__name__).info(comment)
 
     return final_builder.build(valid)

--- a/tests/json_contract/contract_test.py
+++ b/tests/json_contract/contract_test.py
@@ -13,19 +13,22 @@
 # limitations under the License.
 
 
+# pylint: disable=missing-docstring
+# pylint: disable=invalid-name
+
 import unittest
 
 from citest.base import JsonSnapshotHelper
 import citest.json_contract as jc
-
+import citest.json_predicate as jp
 
 _LETTER_ARRAY = ['a', 'b', 'c']
 _NUMBER_ARRAY = [1, 2, 3]
 
-_LETTER_DICT = { 'a':'A', 'b':'B', 'z':'Z' }
-_NUMBER_DICT = { 'a':1, 'b':2, 'three':3 }
-_MIXED_DICT  = {'a':'A', 'b':2, 'x':'X'}
-_COMPOSITE_DICT = { 'letters': _LETTER_DICT, 'numbers': _NUMBER_DICT }
+_LETTER_DICT = {'a':'A', 'b':'B', 'z':'Z'}
+_NUMBER_DICT = {'a':1, 'b':2, 'three':3}
+_MIXED_DICT = {'a':'A', 'b':2, 'x':'X'}
+_COMPOSITE_DICT = {'letters': _LETTER_DICT, 'numbers': _NUMBER_DICT}
 
 
 class FakeObserver(jc.ObjectObserver):
@@ -41,6 +44,8 @@ class FakeObserver(jc.ObjectObserver):
 
 class JsonContractTest(unittest.TestCase):
   def assertEqual(self, expect, have, msg=''):
+    if not msg:
+      msg = 'EXPECTED\n{0!r}\nGOT\n{1!r}'.format(expect, have)
     JsonSnapshotHelper.AssertExpectedValue(expect, have, msg)
 
   def test_clause_success(self):
@@ -48,13 +53,13 @@ class JsonContractTest(unittest.TestCase):
     observation.add_object('A')
     fake_observer = FakeObserver(observation)
 
-    eq_A = jc.STR_EQ('A')
-    verifier = jc.ValueObservationVerifier('Has A', mapped_constraints=[eq_A])
+    eq_A = jp.STR_EQ('A')
+    verifier = jc.ValueObservationVerifier('Has A', constraints=[eq_A])
 
     clause = jc.ContractClause('TestClause', fake_observer, verifier)
 
     expect_result = jc.contract.ContractClauseVerifyResult(
-      True, clause, verifier(observation))
+        True, clause, verifier(observation))
     result = clause.verify()
     self.assertEqual(expect_result, result)
     self.assertTrue(result)
@@ -64,13 +69,13 @@ class JsonContractTest(unittest.TestCase):
     observation.add_object('B')
     fake_observer = FakeObserver(observation)
 
-    eq_A = jc.STR_EQ('A')
-    verifier = jc.ValueObservationVerifier('Has A', mapped_constraints=[eq_A])
+    eq_A = jp.STR_EQ('A')
+    verifier = jc.ValueObservationVerifier('Has A', constraints=[eq_A])
 
     clause = jc.ContractClause('TestClause', fake_observer, verifier)
 
     expect_result = jc.contract.ContractClauseVerifyResult(
-      False, clause, verifier(observation))
+        False, clause, verifier(observation))
     result = clause.verify()
     self.assertEqual(expect_result, result)
     self.assertFalse(result)
@@ -80,8 +85,8 @@ class JsonContractTest(unittest.TestCase):
     observation.add_object('A')
     fake_observer = FakeObserver(observation)
 
-    eq_A = jc.STR_EQ('A')
-    verifier = jc.ValueObservationVerifier('Has A', mapped_constraints=[eq_A])
+    eq_A = jp.STR_EQ('A')
+    verifier = jc.ValueObservationVerifier('Has A', constraints=[eq_A])
 
     clause = jc.ContractClause('TestClause', fake_observer, verifier)
     contract = jc.Contract()
@@ -98,8 +103,8 @@ class JsonContractTest(unittest.TestCase):
     observation.add_object('B')
     fake_observer = FakeObserver(observation)
 
-    eq_A = jc.STR_EQ('A')
-    verifier = jc.ValueObservationVerifier('Has A', mapped_constraints=[eq_A])
+    eq_A = jp.STR_EQ('A')
+    verifier = jc.ValueObservationVerifier('Has A', constraints=[eq_A])
 
     clause = jc.ContractClause('TestClause', fake_observer, verifier)
     contract = jc.Contract()
@@ -117,8 +122,8 @@ class JsonContractTest(unittest.TestCase):
     observation.add_object('B')
     fake_observer = FakeObserver(observation)
 
-    eq_A = jc.STR_EQ('A')
-    verifier = jc.ValueObservationVerifier('Has A', mapped_constraints=[eq_A])
+    eq_A = jp.STR_EQ('A')
+    verifier = jc.ValueObservationVerifier('Has A', constraints=[eq_A])
 
     clause = jc.ContractClause('TestClause', fake_observer, verifier)
     contract = jc.Contract()
@@ -135,10 +140,10 @@ class JsonContractTest(unittest.TestCase):
     observation.add_object('A')
     fake_observer = FakeObserver(observation)
 
-    eq_A = jc.STR_EQ('A')
-    eq_B = jc.STR_EQ('B')
+    eq_A = jp.STR_EQ('A')
+    eq_B = jp.STR_EQ('B')
     verifier = jc.ValueObservationVerifier(
-        'Has A and B', mapped_constraints=[eq_A, eq_B])
+        'Has A and B', constraints=[eq_A, eq_B])
 
     clause = jc.ContractClause('TestClause', fake_observer, verifier)
     contract = jc.Contract()
@@ -190,7 +195,7 @@ class JsonContractTest(unittest.TestCase):
     observation.add_object('C')
     fake_observer = FakeObserver(observation)
 
-    eq_A_or_B = jc.OR([jc.STR_EQ('A'), jc.STR_EQ('B')])
+    eq_A_or_B = jp.OR([jp.STR_EQ('A'), jp.STR_EQ('B')])
     builder = jc.ValueObservationVerifierBuilder('Test Multiple')
     builder.contains_path_pred(None, eq_A_or_B, min=2)
 
@@ -206,12 +211,11 @@ class JsonContractTest(unittest.TestCase):
   def test_contract_observation_failure(self):
     observation = jc.Observation()
     observation.add_error(
-        jc.PredicateResult(False, comment='Observer Failed'))
+        jp.PredicateResult(False, comment='Observer Failed'))
     fake_observer = FakeObserver(observation)
-    error = jc.ObservationFailedError(observation.errors)
 
-    eq_A = jc.STR_EQ('A')
-    verifier = jc.ValueObservationVerifier('Has A', mapped_constraints=[eq_A])
+    eq_A = jp.STR_EQ('A')
+    verifier = jc.ValueObservationVerifier('Has A', constraints=[eq_A])
 
     clause = jc.ContractClause('TestClause', fake_observer, verifier)
     contract = jc.Contract()

--- a/tests/json_contract/observation_failure_test.py
+++ b/tests/json_contract/observation_failure_test.py
@@ -12,84 +12,87 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pylint: disable=missing-docstring
+
 
 import unittest
 
 from citest.base import JsonSnapshotHelper
 import citest.json_contract as jc
+import citest.json_predicate as jp
 
 
 class TestIoErrorFailureVerifier(jc.ObservationFailureVerifier):
-    def _error_comment_or_none(self, error):
-      if isinstance(error, IOError):
-        return 'HAVE {0}'.format(error.message)
-      return None
+  def _error_comment_or_none(self, error):
+    if isinstance(error, IOError):
+      return 'HAVE {0}'.format(error.message)
+    return None
 
 
 class ObservationFailureTest(unittest.TestCase):
   def assertEqual(self, expect, have, msg=''):
     JsonSnapshotHelper.AssertExpectedValue(expect, have, msg)
 
-  def testObservationFailedErrorEqual(self):
-      self.assertEqual(
-            jc.ObservationFailedError([], valid=True),
-            jc.ObservationFailedError([], valid=True))
-      self.assertEqual(
-            jc.ObservationFailedError([ValueError('blah')], valid=True),
-            jc.ObservationFailedError([ValueError('blah')], valid=True))
-      self.assertNotEqual(
-            jc.ObservationFailedError([], valid=True),
-            jc.ObservationFailedError([], valid=False))
-      self.assertNotEqual(
-            jc.ObservationFailedError([ValueError('blah')], valid=True),
-            jc.ObservationFailedError([TypeError('blah')], valid=True))
+  def test_observation_failed_error_equal(self):
+    self.assertEqual(
+        jc.ObservationFailedError([], valid=True),
+        jc.ObservationFailedError([], valid=True))
+    self.assertEqual(
+        jc.ObservationFailedError([ValueError('blah')], valid=True),
+        jc.ObservationFailedError([ValueError('blah')], valid=True))
+    self.assertNotEqual(
+        jc.ObservationFailedError([], valid=True),
+        jc.ObservationFailedError([], valid=False))
+    self.assertNotEqual(
+        jc.ObservationFailedError([ValueError('blah')], valid=True),
+        jc.ObservationFailedError([TypeError('blah')], valid=True))
 
-  def __doTestObservationFailureVerifierWithError(self, klass):
-      valid = klass == IOError
-      error = klass('Could not connect')
-      observation = jc.Observation()
-      observation.add_error(error)
+  def __do_test_observation_failure_verifier_with_error(self, klass):
+    valid = klass == IOError
+    error = klass('Could not connect')
+    observation = jc.Observation()
+    observation.add_error(error)
 
-      verifier = TestIoErrorFailureVerifier('Test')
-      result = verifier(observation)
-      self.assertEqual(valid, result.valid)
+    verifier = TestIoErrorFailureVerifier('Test')
+    result = verifier(observation)
+    self.assertEqual(valid, result.valid)
 
-      if valid:
-        attempt = jc.ObjectResultMapAttempt(
-            observation, jc.ObservationFailedError([error], valid=valid))
-        self.assertFalse(result.bad_results)
-        self.assertEqual([attempt], result.good_results)
-        self.assertEqual('HAVE Could not connect', result.comment)
-      else:
-        attempt = jc.ObjectResultMapAttempt(
-            observation,
-            jc.PredicateResult(
-                valid=False, comment='Expected error was not found.'))
-        self.assertFalse(result.good_results)
-        self.assertEqual([attempt], result.bad_results)
-        self.assertEqual('Expected error was not found.', result.comment)
-
-  def testObservationFailureVerifierWithExpectedError(self):
-      self.__doTestObservationFailureVerifierWithError(IOError)
-
-  def testObservationFailureVerifierWithUnexpectedError(self):
-      self.__doTestObservationFailureVerifierWithError(Exception)
-
-  def testObservationFailureVerifierWithoutError(self):
-      observation = jc.Observation()
-
-      verifier = TestIoErrorFailureVerifier('Test')
-      result = verifier(observation)
-      self.assertFalse(result.valid)  # Because has no error
+    if valid:
+      attempt = jp.ObjectResultMapAttempt(
+          observation, jc.ObservationFailedError([error], valid=valid))
+      self.assertFalse(result.bad_results)
+      self.assertEqual([attempt], result.good_results)
+      self.assertEqual('HAVE Could not connect', result.comment)
+    else:
+      attempt = jp.ObjectResultMapAttempt(
+          observation,
+          jp.PredicateResult(
+              valid=False, comment='Expected error was not found.'))
       self.assertFalse(result.good_results)
-      attempt_list = result.bad_results
-      self.assertEqual(
-          [jc.ObjectResultMapAttempt(
-                  observation,
-                  jc.PredicateResult(
-                      valid=False,
-                      comment='Observation had no errors.'))],
-          result.bad_results)
+      self.assertEqual([attempt], result.bad_results)
+      self.assertEqual('Expected error was not found.', result.comment)
+
+  def test_observation_failure_verifier_with_expected_error(self):
+    self.__do_test_observation_failure_verifier_with_error(IOError)
+
+  def test_observation_failure_verifier_with_unexpected_error(self):
+    self.__do_test_observation_failure_verifier_with_error(Exception)
+
+  def test_observation_failure_verifier_without_error(self):
+    observation = jc.Observation()
+
+    verifier = TestIoErrorFailureVerifier('Test')
+    result = verifier(observation)
+    self.assertFalse(result.valid)  # Because has no error
+    self.assertFalse(result.good_results)
+    attempt_list = result.bad_results
+    self.assertEqual(
+        [jp.ObjectResultMapAttempt(
+            observation,
+            jp.PredicateResult(
+                valid=False,
+                comment='Observation had no errors.'))],
+        result.bad_results)
 
 
 if __name__ == '__main__':

--- a/tests/json_contract/observer_test.py
+++ b/tests/json_contract/observer_test.py
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pylint: disable=missing-docstring
 
 import unittest
 import citest.json_contract as jc
+import citest.json_predicate as jp
 
 
-_LETTER_DICT = { 'a':'A', 'b':'B', 'z':'Z' }
-_NUMBER_DICT = { 'a':1, 'b':2, 'three':3 }
-_MIXED_DICT  = {'a':'A', 'b':2, 'x':'X'}
+_LETTER_DICT = {'a':'A', 'b':'B', 'z':'Z'}
+_NUMBER_DICT = {'a':1, 'b':2, 'three':3}
+_MIXED_DICT = {'a':'A', 'b':2, 'x':'X'}
 
 
 class JsonObserverTest(unittest.TestCase):
@@ -31,10 +33,10 @@ class JsonObserverTest(unittest.TestCase):
     expect = jc.Observation()
     self.assertEqual(expect, observation)
 
-    observation.add_error(jc.PredicateResult(False))
+    observation.add_error(jp.PredicateResult(False))
     self.assertNotEqual(expect, observation)
 
-    expect.add_error(jc.PredicateResult(False))
+    expect.add_error(jp.PredicateResult(False))
     self.assertEqual(expect, observation)
 
     observation = jc.Observation()
@@ -77,8 +79,8 @@ class JsonObserverTest(unittest.TestCase):
     self.assertEqual([_NUMBER_DICT], observation.objects)
     self.assertEqual(expected, observation)
 
-    pred_list = [jc.PathEqPredicate('a', 'A'), jc.PathEqPredicate('b', 'B')]
-    conjunction = jc.AND(pred_list)
+    pred_list = [jp.PathEqPredicate('a', 'A'), jp.PathEqPredicate('b', 'B')]
+    conjunction = jp.AND(pred_list)
     observer = jc.ObjectObserver(conjunction)
     observation = jc.Observation()
 
@@ -104,14 +106,14 @@ class JsonObserverTest(unittest.TestCase):
     self.assertEqual(expected, observation)
 
   def test_observation_strict_vs_nonstrict(self):
-    aA = jc.PathEqPredicate('a', 'A')
-    bB = jc.PathEqPredicate('b', 'B')
+    aA = jp.PathEqPredicate('a', 'A')
+    bB = jp.PathEqPredicate('b', 'B')
 
     unstrict_object_list = [_NUMBER_DICT, _LETTER_DICT, _MIXED_DICT]
     unstrict_observation = jc.Observation()
     unstrict_observation.add_all_objects(unstrict_object_list)
 
-    strict_object_list = [_LETTER_DICT, { 'a':'A', 'b':'B', 'x':'X' }]
+    strict_object_list = [_LETTER_DICT, {'a':'A', 'b':'B', 'x':'X'}]
     strict_observation = jc.Observation()
     strict_observation.add_all_objects(strict_object_list)
 
@@ -119,12 +121,13 @@ class JsonObserverTest(unittest.TestCase):
     none_observation = jc.Observation()
     none_observation.add_all_objects(none_object_list)
 
+    # pylint: disable=bad-whitespace
     test_cases = [
-      #  Name      jc.Observation        Strict,  Unstrict
-      #---------------------------------------------------
-      ('Strict',   strict_observation,   True,    True),
-      ('Unstrict', unstrict_observation, False,   True),
-      ('None',     none_observation,     False,   False)
+        #  Name      jc.Observation        Strict,  Unstrict
+        #---------------------------------------------------
+        ('Strict',   strict_observation,   True,    True),
+        ('Unstrict', unstrict_observation, False,   True),
+        ('None',     none_observation,     False,   False)
     ]
 
     # For each of the cases, test it with strict and non-strict verification.
@@ -137,7 +140,7 @@ class JsonObserverTest(unittest.TestCase):
         test_strict = index == 2
         expected = test[index]
         verifier = jc.ValueObservationVerifier(
-          title='Verifier', mapped_constraints=[aA, bB], strict=test_strict)
+            title='Verifier', constraints=[aA, bB], strict=test_strict)
 
         verify_result = verifier(observation)
         try:

--- a/tests/json_contract/value_observation_verifier_test.py
+++ b/tests/json_contract/value_observation_verifier_test.py
@@ -12,56 +12,63 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pylint: disable=missing-docstring
+# pylint: disable=invalid-name
+
 
 import unittest
 
 from citest.base import JsonSnapshotHelper
 import citest.json_contract as jc
+import citest.json_predicate as jp
 
 
-_LETTER_DICT = { 'a':'A', 'b':'B', 'z':'Z' }
-_NUMBER_DICT = { 'a':1, 'b':2, 'three':3 }
+_LETTER_DICT = {'a':'A', 'b':'B', 'z':'Z'}
+_NUMBER_DICT = {'a':1, 'b':2, 'three':3}
 
-_COMPOSITE_DICT = { 'letters': _LETTER_DICT, 'numbers': _NUMBER_DICT }
+_COMPOSITE_DICT = {'letters': _LETTER_DICT, 'numbers': _NUMBER_DICT}
 
 _LETTER_ARRAY = ['a', 'b', 'c']
 _NUMBER_ARRAY = [1, 2, 3]
 _DICT_ARRAY = [{}, _LETTER_DICT, _NUMBER_DICT, _COMPOSITE_DICT]
-_MULTI_ARRAY = [ _LETTER_DICT, _NUMBER_DICT, _LETTER_DICT, _NUMBER_DICT]
+_MULTI_ARRAY = [_LETTER_DICT, _NUMBER_DICT, _LETTER_DICT, _NUMBER_DICT]
 
 
 class JsonValueObservationVerifierTest(unittest.TestCase):
   def assertEqual(self, expect, have, msg=''):
-    JsonSnapshotHelper.AssertExpectedValue(expect, have, msg)
+    try:
+      JsonSnapshotHelper.AssertExpectedValue(expect, have, msg)
+    except AssertionError:
+      print 'EXPECTED\n{0!r}\nGOT\n{1!r}'.format(expect, have)
 
   def test_verifier_builder_add_constraint(self):
-      aA = jc.PathPredicate('a', jc.STR_EQ('A'))
-      bB = jc.PathPredicate('b', jc.STR_EQ('B'))
-      builder = jc.ValueObservationVerifierBuilder('TestAddConstraint')
-      builder.add_constraint(aA)
-      builder.add_constraint(bB)
-      verifier = builder.build()
-      self.assertEqual('TestAddConstraint', verifier.title)
-      self.assertEqual([aA, bB], verifier.constraints)
+    aA = jp.PathPredicate('a', jp.STR_EQ('A'))
+    bB = jp.PathPredicate('b', jp.STR_EQ('B'))
+    builder = jc.ValueObservationVerifierBuilder('TestAddConstraint')
+    builder.add_constraint(aA)
+    builder.add_constraint(bB)
+    verifier = builder.build()
+    self.assertEqual('TestAddConstraint', verifier.title)
+    self.assertEqual([aA, bB], verifier.constraints)
 
   def test_verifier_builder_contains_pred_list(self):
-      aA = jc.PathPredicate('a', jc.STR_EQ('A'))
-      bB = jc.PathPredicate('b', jc.STR_EQ('B'))
-      builder = jc.ValueObservationVerifierBuilder('TestContainsGroup')
-      builder.contains_path_pred('a', jc.STR_EQ('A'))
-      builder.contains_path_pred('b', jc.STR_EQ('B'))
-      verifier = builder.build()
+    aA = jp.PathPredicate('a', jp.STR_EQ('A'))
+    bB = jp.PathPredicate('b', jp.STR_EQ('B'))
+    builder = jc.ValueObservationVerifierBuilder('TestContainsGroup')
+    builder.contains_path_pred('a', jp.STR_EQ('A'))
+    builder.contains_path_pred('b', jp.STR_EQ('B'))
+    verifier = builder.build()
 
-      count_aA = jc.CardinalityPredicate(aA, 1, None)
-      count_bB = jc.CardinalityPredicate(bB, 1, None)
-      self.assertEqual([count_aA, count_bB], verifier.constraints)
+    count_aA = jp.CardinalityPredicate(aA, 1, None)
+    count_bB = jp.CardinalityPredicate(bB, 1, None)
+    self.assertEqual([count_aA, count_bB], verifier.constraints)
 
   def test_object_observation_verifier_multiple_constraint_found(self):
-    pred_list = [jc.PathPredicate('a', jc.STR_EQ('A')),
-                 jc.PathPredicate('b', jc.STR_EQ('B'))]
+    pred_list = [jp.PathPredicate('a', jp.STR_EQ('A')),
+                 jp.PathPredicate('b', jp.STR_EQ('B'))]
     # This is our object verifier for these tests.
     verifier = jc.ValueObservationVerifier(
-        title='Find Both', mapped_constraints=pred_list)
+        title='Find Both', constraints=pred_list)
 
     test_cases = [('dict', _LETTER_DICT),
                   ('array', _DICT_ARRAY),
@@ -77,7 +84,7 @@ class JsonValueObservationVerifierTest(unittest.TestCase):
         observation.add_object(obj)
 
       for pred in pred_list:
-        builder.add_map_result(jc.MapPredicate(pred)(observation.objects))
+        builder.add_path_predicate_result(pred(observation.objects))
 
       # All of these tests succeed.
       verify_results = builder.build(True)
@@ -89,11 +96,11 @@ class JsonValueObservationVerifierTest(unittest.TestCase):
         raise
 
   def test_object_observation_verifier_one_constraint_not_found(self):
-    pred_list = [jc.PathPredicate('a', jc.STR_EQ('NOT_FOUND'))]
+    pred_list = [jp.PathPredicate('a', jp.STR_EQ('NOT_FOUND'))]
 
     # This is our object verifier for these tests.
     verifier = jc.ValueObservationVerifier(
-        title='Cannot find one', mapped_constraints=pred_list)
+        title='Cannot find one', constraints=pred_list)
 
     test_cases = [('array', _DICT_ARRAY),
                   ('dict', _LETTER_DICT),
@@ -111,7 +118,7 @@ class JsonValueObservationVerifierTest(unittest.TestCase):
         observation.add_object(obj)
 
       for pred in pred_list:
-        builder.add_map_result(jc.MapPredicate(pred)(observation.objects))
+        builder.add_path_predicate_result(pred(observation.objects))
 
       # None of these tests succeed.
       verify_results = builder.build(False)
@@ -123,12 +130,12 @@ class JsonValueObservationVerifierTest(unittest.TestCase):
         raise
 
   def test_object_observation_verifier_multiple_constraint_not_found(self):
-    pred_list = [jc.PathPredicate('a', jc.STR_EQ('NOT_FOUND')),
-                 jc.PathPredicate('b', jc.STR_EQ('NOT_FOUND'))]
+    pred_list = [jp.PathPredicate('a', jp.STR_EQ('NOT_FOUND')),
+                 jp.PathPredicate('b', jp.STR_EQ('NOT_FOUND'))]
 
     # This is our object verifier for these tests.
     verifier = jc.ValueObservationVerifier(
-        title='Cannot find either', mapped_constraints=pred_list)
+        title='Cannot find either', constraints=pred_list)
 
     test_cases = [('array', _DICT_ARRAY),
                   ('dict', _LETTER_DICT),
@@ -146,7 +153,7 @@ class JsonValueObservationVerifierTest(unittest.TestCase):
         observation.add_object(obj)
 
       for pred in pred_list:
-        builder.add_map_result(jc.MapPredicate(pred)(observation.objects))
+        builder.add_path_predicate_result(pred(observation.objects))
 
       # None of these tests succeed.
       verify_results = builder.build(False)
@@ -158,12 +165,12 @@ class JsonValueObservationVerifierTest(unittest.TestCase):
         raise
 
   def test_object_observation_verifier_some_but_not_all_constraints_found(self):
-    pred_list = [jc.PathPredicate('a', jc.STR_EQ('NOT_FOUND')),
-                 jc.PathPredicate('b', jc.STR_EQ('B'))]
+    pred_list = [jp.PathPredicate('a', jp.STR_EQ('NOT_FOUND')),
+                 jp.PathPredicate('b', jp.STR_EQ('B'))]
 
     # This is our object verifier for these tests.
     verifier = jc.ValueObservationVerifier(
-        title='Find one of two', mapped_constraints=pred_list)
+        title='Find one of two', constraints=pred_list)
 
     test_cases = [('array', _DICT_ARRAY),
                   ('dict', _LETTER_DICT),
@@ -181,7 +188,8 @@ class JsonValueObservationVerifierTest(unittest.TestCase):
         observation.add_object(obj)
 
       for pred in pred_list:
-        builder.add_map_result(jc.MapPredicate(pred)(observation.objects))
+        pred_result = jp.PathPredicate('', pred)(observation.objects)
+        builder.add_path_predicate_result(pred(observation.objects))
 
       # None of these tests succeed.
       verify_results = builder.build(False)
@@ -193,58 +201,56 @@ class JsonValueObservationVerifierTest(unittest.TestCase):
         raise
 
   def test_object_observation_verifier_with_conditional(self):
-      # We need strict True here because we want each object to pass
-      # the constraint test. Otherwise, if any object passes, then the whole
-      # observation would pass. This causes a problem when we say that
-      # we dont ever want to see 'name' unless it has a particular 'value'.
-      # Without strict test, we'd allow this to occur as long as another object
-      # satisfied that constraint.
-      # When we use 'excludes', it applies to the whole observation since this
-      # is normally the intent. However, here we are excluding values under
-      # certain context -- "If the 'name' field is 'NAME' then it must contain
-      # a value field 'VALUE'". Excluding name='NAME' everywhere would
-      # not permit the context where value='VALUE' which we want to permit.
-      builder = jc.ValueObservationVerifierBuilder(
+    # We need strict True here because we want each object to pass
+    # the constraint test. Otherwise, if any object passes, then the whole
+    # observation would pass. This causes a problem when we say that
+    # we dont ever want to see 'name' unless it has a particular 'value'.
+    # Without strict test, we'd allow this to occur as long as another object
+    # satisfied that constraint.
+    # When we use 'excludes', it applies to the whole observation since this
+    # is normally the intent. However, here we are excluding values under
+    # certain context -- "If the 'name' field is 'NAME' then it must contain
+    # a value field 'VALUE'". Excluding name='NAME' everywhere would
+    # not permit the context where value='VALUE' which we want to permit.
+    verifier_builder = jc.ValueObservationVerifierBuilder(
         title='Test Conditional', strict=True)
 
-      name_eq_pred = jc.PathEqPredicate('name', 'NAME')
-      value_eq_pred = jc.PathEqPredicate('value', 'VALUE')
-      name_value_pred = jc.AND([name_eq_pred, value_eq_pred])
-      no_name_pred = jc.NOT(name_eq_pred)
+    name_eq_pred = jp.PathEqPredicate('name', 'NAME')
+    value_eq_pred = jp.PathEqPredicate('value', 'VALUE')
 
-      conditional = jc.IF(name_eq_pred, value_eq_pred)
-      pred_list = [conditional]
-      builder.add_mapped_constraint(conditional)
+    conditional = jp.IF(name_eq_pred, value_eq_pred)
+    pred_list = [jp.PathPredicate('', conditional)]
+    verifier_builder.add_constraint(conditional)
 
-      match_name_value_obj = {'name':'NAME', 'value':'VALUE'}
-      match_value_not_name_obj = {'name':'GOOD', 'value':'VALUE'}
-      match_neither_obj = {'name':'GOOD', 'value':'GOOD'}
-      match_name_not_value_obj = {'name':'NAME', 'value':'BAD'}   # bad
+    match_name_value_obj = {'name':'NAME', 'value':'VALUE'}
+    match_value_not_name_obj = {'name':'GOOD', 'value':'VALUE'}
+    match_neither_obj = {'name':'GOOD', 'value':'GOOD'}
+    match_name_not_value_obj = {'name':'NAME', 'value':'BAD'}   # bad
 
-      test_cases = [(True, [match_name_value_obj, match_neither_obj]),
-                    (True, [match_value_not_name_obj, match_neither_obj]),
-                    (False, [match_neither_obj, match_name_not_value_obj])]
+    test_cases = [(True, [match_name_value_obj, match_neither_obj]),
+                  (True, [match_value_not_name_obj, match_neither_obj]),
+                  (False, [match_neither_obj, match_name_not_value_obj])]
 
-      verifier = builder.build()
-      for test in test_cases:
-        observation = jc.Observation()
-        builder = jc.ObservationVerifyResultBuilder(observation)
+    verifier = verifier_builder.build()
+    for test in test_cases:
+      observation = jc.Observation()
+      result_builder = jc.ObservationVerifyResultBuilder(observation)
 
-        expect_valid = test[0]
-        obj_list = test[1]
-        observation.add_all_objects(obj_list)
+      expect_valid = test[0]
+      obj_list = test[1]
+      observation.add_all_objects(obj_list)
 
-        for pred in pred_list:
-          builder.add_map_result(jc.MapPredicate(pred)(observation.objects))
+      for pred in pred_list:
+        result_builder.add_path_predicate_result(pred(observation.objects))
 
-        # All of these tests succeed.
-        verify_results = builder.build(expect_valid)
+      # All of these tests succeed.
+      verify_results = result_builder.build(expect_valid)
 
-        try:
-          self._try_verify(verifier, observation, expect_valid, verify_results)
-        except:
-          print 'testing {0}'.format(obj_list)
-          raise
+      try:
+        self._try_verify(verifier, observation, expect_valid, verify_results)
+      except:
+        print 'testing {0}'.format(obj_list)
+        raise
 
   def _try_verify(self, verifier, observation, expect_ok, expect_results=None,
                   dump=False):
@@ -264,10 +270,10 @@ class JsonValueObservationVerifierTest(unittest.TestCase):
 
     ok = verify_results.__nonzero__()
     if dump:
-      print 'GOT RESULTS:\n{0}\n'.format(
-        JsonSnapshotHelper.ValueToEncodedJson(verify_results))
-      print '\nExpected:\n{0}\n'.format(
-        JsonSnapshotHelper.ValueToEncodedJson(expect_results))
+      print 'GOT RESULTS {0}:\n{1!r}\n'.format(
+          verify_results.__class__.__name__, verify_results)
+      print '\nExpected {0}:\n{1!r}\n'.format(
+          expect_results.__class__.__name__, expect_results)
 
     self.assertEqual(expect_ok, ok)
     if expect_results:


### PR DESCRIPTION
@lwander This is step 3, updating the contract and observers to be aware of the changes to the predicates. The main change here is that the verifier is now more based on PathPredicate than MapPredicate. Even so, since the results are only used for reporting and are self describing, there isnt further down-stream impact