### PR TITLE
Updated remaining modules affected by refactoring to complete it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,51 +12,69 @@ if appropriate.
 A test case might look something like this:
 
 ```
-  def create_load_balancer(self):
-    load_balancer_name = self._bindings['TEST_APP_COMPONENT_NAME']
+  def create_google_load_balancer(self):
+    bindings = self._bindings
+    load_balancer_name = bindings['TEST_APP_COMPONENT_NAME']
+
+    spec = {
+        'checkIntervalSec': 9,
+        'healthyThreshold': 3,
+        'unhealthyThreshold': 5,
+        'timeoutSec': 2,
+        'port': 80
+    }
+
     target_pool_name = '{0}/targetPools/{1}-tp'.format(
-      self._bindings['TEST_REGION'], load_balancer_name)
+        bindings['TEST_REGION'], load_balancer_name)
 
-    payload = self.substitute_variables(
-      '{"job":'
-      '[{'
-        '"provider":"gce",'
-        '"stack":"$TEST_STACK",'
-        '"detail":"$TEST_COMPONENT_DETAIL",'
-        '"credentials":"$TEST_ACCOUNT_NAME",'
-        '"region":"$TEST_REGION",'
-        '"healthCheckPort":80,'
-        '"healthTimeout":1,"healthInterval":1,'
-        '"healthyThreshold":1,"unhealthyThreshold":1,'
-        '"listeners":[{"protocol":"TCP","portRange":"80","healthCheck":true}],'
-        '"name":"' + load_balancer_name + '",'
-        '"providerType":"gce",'
-        '"healthCheck":"HTTP:80/",'
-        '"type":"upsertAmazonLoadBalancer",'
-        '"availabilityZones":{"$TEST_REGION":[]},'
-        '"user":"[anonymous]"'
-      '}],'
-      '"application":"$TEST_APP_NAME",'
-      '"description":"Create Load Balancer: ' + load_balancer_name + '"}'
-    )
+        job=[{
+            'cloudProvider': 'gce',
+            'provider': 'gce',
+            'stack': bindings['TEST_STACK'],
+            'detail': bindings['TEST_COMPONENT_DETAIL'],
+            'credentials': bindings['GCE_CREDENTIALS'],
+            'region': bindings['TEST_GCE_REGION'],
+            'ipProtocol': 'TCP',
+            'portRange': spec['port'],
+            'loadBalancerName': load_balancer_name,
+            'healthCheck': {
+                'port': spec['port'],
+                'timeoutSec': spec['timeoutSec'],
+                'checkIntervalSec': spec['checkIntervalSec'],
+                'healthyThreshold': spec['healthyThreshold'],
+                'unhealthyThreshold': spec['unhealthyThreshold'],
+            },
+            'type': 'upsertLoadBalancer',
+            'availabilityZones': {bindings['TEST_GCE_REGION']: []},
+            'user': '[anonymous]'
+        }],
+        description='Create Load Balancer: ' + load_balancer_name,
+        application=bindings['TEST_APP'])
 
-    contract = GceContract(self._gcloud)
-    (contract.new_clause('Health Check Added')
-       .list_resources('http-health-checks')
-       .contains('name', '%s-hc' % load_balancer_name))
-    (contract.new_clause('Target Pool Added')
-       .list_resources('target-pools')
-       .contains('name', '%s-tp' % load_balancer_name))
-    (contract.new_clause('Forwarding Rules Added', retryable_for_secs=30)
-       .list_resources('forwarding-rules')
-       .contains_group([PathContains('name', load_balancer_name),
-                        PathContains('target', target_pool_name)]))
+    builder = gcp_testing.GceContractBuilder(self.gce_observer)
+    (builder.new_clause_builder('Health Check Added',
+                                retryable_for_secs=30)
+     .list_resources('http-health-checks')
+     .contains_pred_list(
+         [json_predicate.PathContainsPredicate(
+              'name', '%s-hc' % load_balancer_name),
+          json_predicate.DICT_SUBSET(spec)]))
+    (builder.new_clause_builder('Target Pool Added',
+                                retryable_for_secs=30)
+     .list_resources('target-pools')
+     .contains_path_value('name', '%s-tp' % load_balancer_name))
+    (builder.new_clause_builder('Forwarding Rules Added',
+                                retryable_for_secs=30)
+     .list_resources('forwarding-rules')
+     .contains_pred_list([
+          json_predicate.PathContainsPredicate('name', load_balancer_name),
+          json_predicate.PathContainsPredicate('target', target_pool_name)]))
 
-    test_case = OperationTestCase(
-      self.newPostOperation(
-        title='create_load_balancer', data=payload,
-        path='applications/%s/tasks' % self.TEST_APP_NAME),
-      contract=contract)
+    return service_testing.OperationContract(
+        self.new_post_operation(
+            title='upsert_load_balancer', data=payload, path='tasks'),
+        contract=builder.build())
+
 ```
 
 
@@ -116,7 +134,8 @@ meets or does not meet expectations, ultimately passing or failing the test.
 SubPackage | Purpose
 -------|--------
 base | Introduces some classes and utilities that support other packages.
-json_contract | Introduces a means to specify contracts on JSON documents as a building block for testing.
+json_contract | Introduces a means to specify observers to collect JSON documents, and to define contracts specifying expectations of the collected JSON content.
+json_predicate | Introduces a means to locate and attributes within JSON objects, and compare their values. These are used as the basis of json_contract.
 service_testing | Introduces the core framework, base classes, and generic utilities.
 aws_testing | Specializations and extensions to support testing on Amazon Web Services (AWS)
 gcp_testing | Specializations and extensions to support testing on Google Cloud Platform (GCP)

--- a/citest/aws_testing/aws_contract.py
+++ b/citest/aws_testing/aws_contract.py
@@ -18,6 +18,7 @@
 import json
 
 from .. import json_contract as jc
+from ..json_predicate import JsonError
 from ..service_testing import cli_agent
 
 class AwsObjectObserver(jc.ObjectObserver):
@@ -51,7 +52,7 @@ class AwsObjectObserver(jc.ObjectObserver):
     except (ValueError, UnicodeError) as e:
       error = 'Invalid JSON in response: %s' % str(aws_response)
       print 'ERROR:' + error
-      observation.add_error(jc.JsonError(error, e))
+      observation.add_error(JsonError(error, e))
       return []
 
     if not isinstance(doc, list):

--- a/citest/gcp_testing/gce_contract.py
+++ b/citest/gcp_testing/gce_contract.py
@@ -22,6 +22,7 @@ import traceback
 
 # Our modules.
 from .. import json_contract as jc
+from ..json_predicate import JsonError
 from ..service_testing import cli_agent
 
 class GCloudObjectObserver(jc.ObjectObserver):
@@ -63,7 +64,7 @@ class GCloudObjectObserver(jc.ObjectObserver):
       error = 'Invalid JSON in response: %s' % str(gcloud_response)
       logging.getLogger(__name__).info('%s\n%s\n----------------\n',
                                        error, traceback.format_exc())
-      observation.add_error(jc.JsonError(error, vex))
+      observation.add_error(JsonError(error, vex))
       return []
 
     return observation.objects

--- a/citest/json_predicate/__init__.py
+++ b/citest/json_predicate/__init__.py
@@ -22,6 +22,8 @@ operations to see if their values are consistent with expectations.
 # pylint: disable=relative-import
 
 
+from .json_error import JsonError
+
 # This module is intended to support the higher level json_predicate.* modules.
 # To that end, the lookups populate PredicateResult objects rather than just
 # returning values, so are heavier weight that would be otherwise.

--- a/citest/reporting/html_index_renderer.py
+++ b/citest/reporting/html_index_renderer.py
@@ -88,6 +88,8 @@ class HtmlIndexRenderer(JournalProcessor):
             self.__passed_count += 1
           elif relation == 'INVALID':
             self.__failed_count += 1
+          elif relation == 'ERROR':
+            self.__failed_count += 1
           else:
             raise ValueError('Unhandled relation {0}'.format(relation))
         return

--- a/citest/service_testing/http_observer.py
+++ b/citest/service_testing/http_observer.py
@@ -21,7 +21,8 @@ import logging
 import traceback
 
 # citest modules.
-import citest.json_contract as jc
+from .. import json_contract as jc
+from ..json_predicate import JsonError
 from . import AgentError
 
 
@@ -86,7 +87,7 @@ class HttpObjectObserver(jc.ObjectObserver):
       error = 'Invalid JSON in response: %s' % content
       logging.getLogger(__name__).info('%s\n%s\n----------------\n',
                                        error, traceback.format_exc())
-      observation.add_error(jc.JsonError(error, ex))
+      observation.add_error(JsonError(error, ex))
       return []
 
     return observation.objects

--- a/spinnaker/spinnaker_system/aws_kato_test.py
+++ b/spinnaker/spinnaker_system/aws_kato_test.py
@@ -61,7 +61,7 @@ import sys
 
 # citest modules.
 import citest.aws_testing as aws
-import citest.json_contract as jc
+import citest.json_predicate as jp
 import citest.service_testing as st
 
 # Spinnaker modules.
@@ -152,12 +152,13 @@ class AwsKatoTestScenario(sk.SpinnakerTestScenario):
          command='describe-load-balancers',
          args=['--load-balancer-names', self.__use_lb_name])
      .contains_pred_list([
-         jc.PathContainsPredicate(
+         jp.PathContainsPredicate(
              'LoadBalancerDescriptions/HealthCheck', health_check),
-         jc.PathPredicate(
-             'LoadBalancerDescriptions/AvailabilityZones',
-             jc.LIST_SIMILAR(avail_zones)),
-         jc.PathElementsContainPredicate(
+         jp.PathPredicate(
+             'LoadBalancerDescriptions/AvailabilityZones{0}'.format(
+                 jp.DONT_ENUMERATE_TERMINAL),
+             jp.LIST_SIMILAR(avail_zones)),
+         jp.PathElementsContainPredicate(
              'LoadBalancerDescriptions/ListenerDescriptions', listener)
          ])
     )

--- a/spinnaker/spinnaker_system/aws_smoke_test.py
+++ b/spinnaker/spinnaker_system/aws_smoke_test.py
@@ -54,6 +54,7 @@ import sys
 # citest modules.
 import citest.aws_testing as aws
 import citest.json_contract as jc
+import citest.json_predicate as jp
 import citest.service_testing as st
 
 # Spinnaker modules.
@@ -252,12 +253,13 @@ class AwsSmokeTestScenario(sk.SpinnakerTestScenario):
          command='describe-load-balancers',
          args=['--load-balancer-names', load_balancer_name])
      .contains_pred_list([
-         jc.PathContainsPredicate(
+         jp.PathContainsPredicate(
              'LoadBalancerDescriptions/HealthCheck', health_check),
-         jc.PathPredicate(
-             'LoadBalancerDescriptions/AvailabilityZones',
-             jc.LIST_SIMILAR(expect_avail_zones)),
-         jc.PathElementsContainPredicate(
+         jp.PathPredicate(
+             'LoadBalancerDescriptions/AvailabilityZones{0}'.format(
+                 jp.DONT_ENUMERATE_TERMINAL),
+             jp.LIST_SIMILAR(expect_avail_zones)),
+         jp.PathElementsContainPredicate(
              'LoadBalancerDescriptions/ListenerDescriptions', listener)
          ])
     )

--- a/spinnaker/spinnaker_system/google_kato_test.py
+++ b/spinnaker/spinnaker_system/google_kato_test.py
@@ -48,7 +48,7 @@ import sys
 from citest.service_testing import HttpContractBuilder
 from citest.service_testing import NoOpOperation
 import citest.gcp_testing as gcp
-import citest.json_contract as jc
+import citest.json_predicate as jp
 import citest.service_testing as st
 
 # Spinnaker modules.
@@ -202,14 +202,14 @@ class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
               .list_resources('instances'))
     for name in names:
       # If one of our instances still exists, it should be STOPPING.
-      name_matches_pred = jc.PathContainsPredicate('name', name)
-      is_stopping_pred = jc.PathEqPredicate('status', 'STOPPING')
+      name_matches_pred = jp.PathContainsPredicate('name', name)
+      is_stopping_pred = jp.PathEqPredicate('status', 'STOPPING')
 
       # We want the condition to apply to all the observed objects so we'll
       # map the constraint over the observation. Otherwise, if dont map it,
       # then we'd expect the constraint to hold somewhere among the observed
       # objects, but not necessarily all of them.
-      clause.add_mapped_constraint(jc.IF(name_matches_pred, is_stopping_pred))
+      clause.add_constraint(jp.IF(name_matches_pred, is_stopping_pred))
 
     # pylint: disable=bad-continuation
     payload = self.agent.type_to_payload(
@@ -241,8 +241,8 @@ class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
     (builder.new_clause_builder('Server Group Tags Added')
         .inspect_resource('managed-instance-groups', server_group_name)
         .contains_pred_list(
-            [jc.PathContainsPredicate('name', server_group_name),
-             jc.PathContainsPredicate(
+            [jp.PathContainsPredicate('name', server_group_name),
+             jp.PathContainsPredicate(
                  "tags/items", ['test-tag-1', 'test-tag-2'])]))
 
     return st.OperationContract(
@@ -307,30 +307,30 @@ class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
     (builder.new_clause_builder('Http Health Check Added')
         .list_resources('http-health-checks')
         .contains_pred_list(
-            [jc.PathContainsPredicate('name', self.__use_http_lb_hc_name),
-             jc.PathContainsPredicate(None, health_check)]))
+            [jp.PathContainsPredicate('name', self.__use_http_lb_hc_name),
+             jp.PathContainsPredicate(None, health_check)]))
     (builder.new_clause_builder('Forwarding Rule Added', retryable_for_secs=15)
        .list_resources('forwarding-rules')
        .contains_pred_list(
-           [jc.PathContainsPredicate('name', self.__use_http_lb_fr_name),
-            jc.PathContainsPredicate('portRange', port_range)]))
+           [jp.PathContainsPredicate('name', self.__use_http_lb_fr_name),
+            jp.PathContainsPredicate('portRange', port_range)]))
     (builder.new_clause_builder('Backend Service Added')
        .list_resources('backend-services')
        .contains_pred_list(
-           [jc.PathContainsPredicate('name', self.__use_http_lb_bs_name),
-            jc.PathElementsContainPredicate(
+           [jp.PathContainsPredicate('name', self.__use_http_lb_bs_name),
+            jp.PathElementsContainPredicate(
                 'healthChecks', self.__use_http_lb_hc_name)]))
     (builder.new_clause_builder('Url Map Added')
        .list_resources('url-maps')
        .contains_pred_list(
-           [jc.PathContainsPredicate('name', self.__use_http_lb_map_name),
-            jc.PathContainsPredicate(
+           [jp.PathContainsPredicate('name', self.__use_http_lb_map_name),
+            jp.PathContainsPredicate(
                 'defaultService', self.__use_http_lb_bs_name)]))
     (builder.new_clause_builder('Target Http Proxy Added')
        .list_resources('target-http-proxies')
        .contains_pred_list(
-           [jc.PathContainsPredicate('name', self.__use_http_lb_proxy_name),
-            jc.PathContainsPredicate('urlMap', self.__use_http_lb_map_name)]))
+           [jp.PathContainsPredicate('name', self.__use_http_lb_proxy_name),
+            jp.PathContainsPredicate('urlMap', self.__use_http_lb_map_name)]))
 
     return st.OperationContract(
         self.new_post_operation(
@@ -415,8 +415,8 @@ class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
     (builder.new_clause_builder('Health Check Added', retryable_for_secs=15)
        .list_resources('http-health-checks')
        .contains_pred_list(
-           [jc.PathContainsPredicate('name', self.__use_lb_hc_name),
-            jc.PathContainsPredicate(None, health_check)]))
+           [jp.PathContainsPredicate('name', self.__use_lb_hc_name),
+            jp.PathContainsPredicate(None, health_check)]))
 
     return st.OperationContract(
       self.new_post_operation(
@@ -476,15 +476,15 @@ class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
                                 retryable_for_secs=15)
        .list_resources('target-pools')
        .contains_pred_list(
-          [jc.PathContainsPredicate('name', self.__use_lb_tp_name),
-           jc.PathEqPredicate('region', self.bindings['TEST_GCE_REGION']),
-           jc.PathElementsContainPredicate(
+          [jp.PathContainsPredicate('name', self.__use_lb_tp_name),
+           jp.PathEqPredicate('region', self.bindings['TEST_GCE_REGION']),
+           jp.PathElementsContainPredicate(
               'instances', self.use_instance_names[0]),
-           jc.PathElementsContainPredicate(
+           jp.PathElementsContainPredicate(
               'instances', self.use_instance_names[1])])
        .excludes_pred_list(
-           [jc.PathContainsPredicate('name', self.__use_lb_tp_name),
-            jc.PathElementsContainPredicate(
+           [jp.PathContainsPredicate('name', self.__use_lb_tp_name),
+            jp.PathElementsContainPredicate(
                 'instances', self.use_instance_names[2])]))
 
     return st.OperationContract(
@@ -521,10 +521,10 @@ class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
           'target-pools',
           extra_args=['--region', self.bindings['TEST_GCE_REGION']])
        .excludes_pred_list(
-          [jc.PathContainsPredicate('name', self.__use_lb_tp_name),
-           jc.PathElementsContainPredicate(
+          [jp.PathContainsPredicate('name', self.__use_lb_tp_name),
+           jp.PathElementsContainPredicate(
               'instances', self.use_instance_names[0]),
-           jc.PathElementsContainPredicate(
+           jp.PathElementsContainPredicate(
               'instances', self.use_instance_names[1])]))
 
     return st.OperationContract(
@@ -565,7 +565,8 @@ class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
     builder = HttpContractBuilder(self.agent)
     (builder.new_clause_builder('Has Expected Images')
        .get_url_path('/gce/images/find')
-       .add_constraint(jc.EQUIVALENT(expect_images)))
+       .add_constraint(jp.PathPredicate(jp.DONT_ENUMERATE_TERMINAL,
+                                        jp.EQUIVALENT(expect_images))))
 
     return st.OperationContract(
         NoOpOperation('List Available Images'),

--- a/spinnaker/spinnaker_system/google_server_group_test.py
+++ b/spinnaker/spinnaker_system/google_server_group_test.py
@@ -4,7 +4,7 @@ import sys
 
 # citest modules.
 import citest.gcp_testing as gcp
-import citest.json_contract as jc
+import citest.json_predicate as jp
 import citest.service_testing as st
 
 # Spinnaker modules.
@@ -233,8 +233,8 @@ class GoogleServerGroupTestScenario(sk.SpinnakerTestScenario):
      .list_resources('managed-instance-groups')
      .contains_path_value('baseInstanceName', self.__server_group_name)
      .excludes_pred_list([
-         jc.PathContainsPredicate('baseInstanceName', self.__server_group_name),
-         jc.PathContainsPredicate('targetPools', 'https')]))
+         jp.PathContainsPredicate('baseInstanceName', self.__server_group_name),
+         jp.PathContainsPredicate('targetPools', 'https')]))
 
     payload = self.agent.make_json_payload_from_kwargs(
         job=job, description='Server Group Test - disable server group',
@@ -263,8 +263,8 @@ class GoogleServerGroupTestScenario(sk.SpinnakerTestScenario):
     (builder.new_clause_builder('Server Group Enabled', retryable_for_secs=90)
      .list_resources('managed-instance-groups')
      .contains_pred_list([
-         jc.PathContainsPredicate('baseInstanceName', self.__server_group_name),
-         jc.PathContainsPredicate('targetPools', 'https')]))
+         jp.PathContainsPredicate('baseInstanceName', self.__server_group_name),
+         jp.PathContainsPredicate('targetPools', 'https')]))
 
     payload = self.agent.make_json_payload_from_kwargs(
         job=job, description='Server Group Test - enable server group',

--- a/spinnaker/spinnaker_system/google_smoke_test.py
+++ b/spinnaker/spinnaker_system/google_smoke_test.py
@@ -47,6 +47,7 @@ import sys
 # citest modules.
 import citest.gcp_testing as gcp
 import citest.json_contract as jc
+import citest.json_predicate as jp
 import citest.service_testing as st
 
 # Spinnaker modules.
@@ -172,8 +173,8 @@ class GoogleSmokeTestScenario(sk.SpinnakerTestScenario):
                                 retryable_for_secs=30)
      .list_resources('http-health-checks')
      .contains_pred_list(
-         [jc.PathContainsPredicate('name', '%s-hc' % load_balancer_name),
-          jc.DICT_SUBSET(spec)]))
+         [jp.PathContainsPredicate('name', '%s-hc' % load_balancer_name),
+          jp.DICT_SUBSET(spec)]))
     (builder.new_clause_builder('Target Pool Added',
                                 retryable_for_secs=30)
      .list_resources('target-pools')
@@ -182,8 +183,8 @@ class GoogleSmokeTestScenario(sk.SpinnakerTestScenario):
                                 retryable_for_secs=30)
      .list_resources('forwarding-rules')
      .contains_pred_list([
-          jc.PathContainsPredicate('name', load_balancer_name),
-          jc.PathContainsPredicate('target', target_pool_name)]))
+          jp.PathContainsPredicate('name', load_balancer_name),
+          jp.PathContainsPredicate('target', target_pool_name)]))
 
     return st.OperationContract(
         self.new_post_operation(


### PR DESCRIPTION
@lwander This is the final refactoring step, mostly updating the package name in the consumers. Since most high level usage is at the contract level, not much is affected.

There is a subtle problem here. The observers want to expand out lists but sometimes contracts are written against the list as a whole (contains an element that...). This is easily fixed by specifying the DONT_ENUMERATE_TERMINAL path, however it is a subtle issue that is going to grow into an annoyance. I'll need to address this, but have higher priority concerns in other projects so need to come back to it later.