### PR TITLE
Added HttpObservationFailureVerifier

### DIFF
--- a/citest/service_testing/__init__.py
+++ b/citest/service_testing/__init__.py
@@ -58,6 +58,7 @@ from http_observer import (
     HttpObjectObserver,
     HttpContractBuilder,
     HttpContractClauseBuilder,
+    HttpObservationFailureVerifier,
     )
 
 from http_scrubber import (


### PR DESCRIPTION
@lwander 
The "_error_comment_or_none" in the base class interface is hacky but I'd like to wait until later to clean it up. This is an enabling CL to add some new spinnaker tests in another CL.