### PR TITLE
2 storage

### DIFF
--- a/citest/gcp_testing/__init__.py
+++ b/citest/gcp_testing/__init__.py
@@ -17,18 +17,22 @@
 
 
 from gcloud_agent import GCloudAgent
-from gce_contract import GceContractBuilder
-from google_cloud_storage_agent import GoogleCloudStorageAgent
-from google_cloud_storage_contract import GoogleCloudStorageContractBuilder
+from gce_contract import GceContractBuilder # DEPRECATED
+from google_cloud_storage_agent import GcpStorageAgent
+from google_cloud_storage_contract import GcpStorageContractBuilder
 from quota_predicate import (
     QuotaPredicate,
     make_quota_contract,
     verify_quota)
 
-from gcp_api import (
-    build_authenticated_service,
+from gcp_agent import (
+    GcpAgent,
+)
+
+from gcp_contract import GcpContractBuilder
+
+from gcp_error_predicates import (
     GoogleAgentObservationFailureVerifier,
     HttpErrorPredicate,
     HttpErrorPredicateResult,
     )
-

--- a/citest/gcp_testing/gcp_agent.py
+++ b/citest/gcp_testing/gcp_agent.py
@@ -1,0 +1,291 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helper functions for creating GCP service agents."""
+
+
+import json
+import logging
+
+import httplib2
+
+from apiclient import discovery
+from oauth2client.service_account import ServiceAccountCredentials
+
+from ..base import JournalLogger
+from ..service_testing import BaseAgent
+
+
+PLATFORM_READ_ONLY_SCOPE = (
+    'https://www.googleapis.com/auth/cloud-platform.read-only'
+    )
+PLATFORM_FULL_SCOPE = 'https://www.googleapis.com/auth/cloud-platform'
+
+
+class GcpAgent(BaseAgent):
+  """Agent that interacts with services specified by the Discovery API."""
+
+  @classmethod
+  def default_discovery_name_and_version(cls):
+    """Returns (Discovery Service name, version) for this agent class.
+
+    The service name and version are used to lookup the API discovery document
+    for internal implementation details.
+    """
+    raise NotImplementedError()
+
+  @classmethod
+  def download_discovery_document(cls, version=None):
+    """Return the discovery document for the specified service.
+
+    Args:
+      version: [String] The service API version.
+    Returns:
+      https://developers.google.com/discovery/v1/reference/apis#resource
+    """
+    api, default_version = cls.default_discovery_name_and_version()
+    if version is None:
+      version = default_version
+
+    service = discovery.build('discovery', 'v1', http=httplib2.Http())
+
+    # pylint: disable=no-member
+    return service.apis().getRest(api=api, version=version).execute()
+
+  @classmethod
+  def make_service(cls, version=None, scopes=None, credentials_path=None):
+    """Instantiate a client service instance.
+
+    Args:
+      version: [string] The version of the API to use.
+      scopes: [string] List of scopes to authorize, or None.
+      credentials_path: [string] Path to json file with credentials, or None.
+
+    Returns:
+      Service
+    """
+    logger = logging.getLogger(__name__)
+    if scopes is None != credentials_path is None:
+      raise ValueError(
+          'Either provide both scopes and credentials_path or neither')
+
+    api, default_version = cls.default_discovery_name_and_version()
+    if version is None:
+      version = default_version
+
+    http = httplib2.Http()
+    if scopes is not None:
+      logger.info('Authenticating %s %s', api, version)
+      credentials = ServiceAccountCredentials.from_json_keyfile_name(
+          credentials_path, scopes=scopes)
+      http = credentials.authorize(http)
+
+    logger.info('Constructing %s service...', api)
+    return discovery.build(api, version, http=http)
+
+  @classmethod
+  def make_agent(cls, version=None,
+                 scopes=None, credentials_path=None,
+                 default_variables=None, **kwargs):
+    """Factory method to create a new agent instance.
+
+    This is a convienence method to create a new instance with standard
+    service and discovery document parameters.
+
+    Args:
+      version: [string] The version of the API to use or None for default.
+      scopes: [string] List of scopes to authorize, or None.
+      credentials_path: [string] Path to json file with credentials, or None.
+      default_variables: [dict] Default variable values to pass to methods.
+         These are only used when the method has a parameter that was not
+         explicitly provided in the invocation.
+    Returns:
+      Agent
+    """
+    # pylint: disable=too-many-arguments
+    service = cls.make_service(version, scopes, credentials_path)
+    discovery_doc = cls.download_discovery_document(version)
+    return cls(service, discovery_doc, default_variables, **kwargs)
+
+  @property
+  def service(self):
+    """The bound service client."""
+    return self.__service
+
+  @property
+  def discovery_document(self):
+    """The Discovery document specifying the bound service."""
+    return self.__discovery_doc
+
+  @property
+  def default_variables(self):
+    """Default variables for method invocations."""
+    return self.__default_variables
+
+  def __init__(self, service, discovery_doc, default_variables=None):
+    """Constructor.
+
+    Args:
+      service: [Service] The service client instance.
+      discovery_doc: [dict] The service's Discovery document.
+      default_variables: [dict] Default variable values to pass to methods.
+         These are only used when the method has a parameter that was not
+         explicitly provided in the invocation.
+    """
+    super(GcpAgent, self).__init__()
+    self.__service = service
+    self.__discovery_doc = discovery_doc
+    self.__default_variables = dict(default_variables or {})
+    self.__api_title = discovery_doc['title']
+    self.__api_name = discovery_doc['name'].title()
+
+  def resource_method_to_variables(
+      self, method, resource_type, resource_id=None, **kwargs):
+    """Determine variable bindings to pass to a method.
+
+    Args:
+      method: [string] The name of the desired method (in the resource_type).
+      resource_type: [string] The resource type operating on.
+      resource_id: [string] The particular instance to operate on, if any.
+      kwargs: Additional variable bindings
+
+    Returns
+      kwargs ammended with additional default variables, if applicable.
+    """
+    discovery_doc = self.discovery_document
+    resource_info = discovery_doc.get('resources', {}).get(resource_type, None)
+    if resource_info is None:
+      raise KeyError('Unknown {0} Resource type={1}'
+                     .format(discovery_doc['name'].title(), resource_type))
+    method_spec = resource_info.get('methods', {}).get(method, None)
+    if method_spec is None:
+      raise KeyError('Unknown method={0} on resource={1}'
+                     .format(method, resource_type))
+    parameters = method_spec.get('parameters', {})
+    result = {key: value for key, value in kwargs.items() if value is not None}
+    resource_id_param = None
+    if resource_id is not None:
+      resource_id_param = method_spec['parameterOrder'][-1]
+      result[resource_id_param] = resource_id
+
+    missing = []
+    for key, key_spec in parameters.items():
+      if key not in kwargs and key != resource_id_param:
+        def_value = self.__default_variables.get(key, None)
+        if def_value is not None:
+          result[key] = def_value
+        elif key_spec.get('required', False):
+          missing.append(key)
+
+    if missing:
+      raise ValueError('"{0}()" is missing required parameters: {1}'
+                       .format(method, missing))
+    return result
+
+  def get_resource(self, resource_type, resource_id=None, **kwargs):
+    """Get instance metadata details.
+
+    Args:
+      resource_type: [string] The type of the resource instance to get.
+      resource_id: [string] The id of the resource instance to get.
+      kwargs: [kwargs] Additional parameters may be required depending
+         on the resource type (such as zone, etc).
+    """
+    return self.invoke_resource(
+        'get', resource_type=resource_type, resource_id=resource_id, **kwargs)
+
+  def invoke_resource(self, method, resource_type, resource_id=None, **kwargs):
+    """Invoke a method on a resource type or instance.
+
+    Args:
+      method: [string] The operation to perform as named under the
+          |resource_type| in the discovery document.
+      resource_type: [string] The type of the resource instance to operate on.
+      resource_id: [string] The id of the resource instance, or None to operate
+        on the resource type or collection.
+      kwargs: [kwargs] Additional parameters may be required depending
+         on the resource type and method.
+    """
+    variables = self.resource_method_to_variables(
+        method, resource_type, resource_id=resource_id, **kwargs)
+
+    resource_obj = vars(self.__service).get(resource_type, None)
+    if resource_obj is None:
+      raise KeyError('Unknown {api} Resource type={type}'
+                     .format(api=self.__api_title, type=resource_type))
+
+    JournalLogger.journal_or_log(
+        'Requesting {type} {method} {vars}'.format(
+            type=resource_type, method=method, vars=variables),
+        _module=self.logger.name,
+        _context='request')
+
+    request = getattr(resource_obj(), method)(**variables)
+    response = request.execute()
+    JournalLogger.journal_or_log(
+        json.JSONEncoder(
+            encoding='utf-8', separators=(',', ': ')).encode(response),
+        _module=self.logger.name, _context='response',
+        format='json')
+
+    return response
+
+  def list_resource(self, resource_type, method_variant='list',
+                    item_list_transform=None, **kwargs):
+    """List the contents of the specified resource.
+
+    Args:
+      resource_type: [string] The name of the resource to list.
+      method_variant: [string] The API method name to invoke.
+      item_list_transform: [lambda items] Converts the list of items into
+         a result list, or None for the identity.
+      kwargs: [kwargs] Additional parameters may be required depending
+         on the resource type (such as zone, etc).
+
+    Returns:
+      A list of resources.
+    """
+    resource_obj = vars(self.__service).get(resource_type, None)
+    if resource_obj is None:
+      raise KeyError('Unknown {api} Resource type={type}'
+                     .format(api=self.__api_title, type=resource_type))
+
+    method_container = resource_obj()
+    variables = self.resource_method_to_variables(
+        method_variant, resource_type, **kwargs)
+    request = getattr(method_container, method_variant)(**variables)
+
+    all_objects = []
+    more = ''
+    while request:
+      JournalLogger.journal_or_log('Listing {0}{1}'.format(more, resource_type),
+                                   _module=self.logger.name,
+                                   _context='request')
+      response = request.execute()
+      JournalLogger.journal_or_log(
+          json.JSONEncoder(
+              encoding='utf-8', separators=(',', ': ')).encode(response),
+          _module=self.logger.name, _context='response',
+          format='json')
+
+      response_items = response.get('items', [])
+      all_items = (item_list_transform(response_items)
+                   if item_list_transform
+                   else response_items)
+      all_objects.extend(all_items)
+      request = method_container.list_next(request, response)
+      more = ' more '
+
+    self.logger.info('Found total=%d %s', len(all_objects), resource_type)
+    return all_objects

--- a/citest/gcp_testing/gcp_contract.py
+++ b/citest/gcp_testing/gcp_contract.py
@@ -1,0 +1,179 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Provides a means for specifying and verifying expectations of GCE state."""
+
+# Standard python modules.
+import logging
+import traceback
+
+from googleapiclient.errors import HttpError
+
+# Our modules.
+from .. import json_contract as jc
+from .gcp_error_predicates import GoogleAgentObservationFailureVerifier
+
+
+class GcpObjectObserver(jc.ObjectObserver):
+  """Observe GCP resources."""
+
+  def __init__(self, method, filter=None, **kwargs):
+    """Construct observer.
+
+    Args:
+      gcp_agent: GcpAgent instance to use.
+      method: [method] The method to invoke.
+      kwargs: [kwargs] arguments to pass to method.
+    """
+    super(GcpObjectObserver, self).__init__(filter)
+
+    self.__method = method
+    self.__kwargs = dict(kwargs)
+
+  def export_to_json_snapshot(self, snapshot, entity):
+    """Implements JsonSnapshotable interface."""
+    snapshot.edge_builder.make_control(entity, 'Args', self.__kwargs)
+    super(GcpObjectObserver, self).export_to_json_snapshot(snapshot, entity)
+
+  def __str__(self):
+    return 'GcpObjectObserver({0})'.format(self.__kwargs)
+
+  def collect_observation(self, observation, trace=True):
+    try:
+      result = self.__method(**self.__kwargs)
+      if isinstance(result, list):
+        observation.add_all_objects(result)
+      else:
+        observation.add_object(result)
+    except HttpError as http_error:
+      logging.getLogger(__name__).info('%s\n%s\n----------------\n',
+                                       http_error, traceback.format_exc())
+      observation.add_error(http_error)
+      return []
+
+    return observation.objects
+
+
+class GcpClauseBuilder(jc.ContractClauseBuilder):
+  """A ContractClause that facilitates observing GCE state."""
+
+  @property
+  def gcp_agent(self):
+    """Returns the bound GcpAgent performing the observations."""
+    return self.__gcp_agent
+
+  def __init__(self, title, gcp_agent, retryable_for_secs=0, strict=False):
+    """Construct new clause.
+
+    Args:
+      title: The string title for the clause is only for reporting purposes.
+      gcp_agent: The GcpAgent to make the observation for the clause to verify.
+      retryable_for_secs: Number of seconds that observations can be retried
+         if their verification initially fails.
+      strict: DEPRECATED flag indicating whether the clauses (added later)
+         must be true for all objects (strict) or at least one (not strict).
+         See ValueObservationVerifierBuilder for more information.
+         This is deprecated because in the future this should be on a per
+         constraint basis.
+    """
+    super(GcpClauseBuilder, self).__init__(
+        title=title, retryable_for_secs=retryable_for_secs)
+    self.__gcp_agent = gcp_agent
+    self.__strict = strict
+
+  def list_resource(self, resource_type, **kwargs):
+    """Observe resources of a particular type."""
+    self.observer = GcpObjectObserver(
+        self.__gcp_agent.list_resource, resource_type=resource_type, **kwargs)
+    observation_builder = jc.ValueObservationVerifierBuilder(
+        'List ' + resource_type, strict=self.__strict)
+    self.verifier_builder.append_verifier_builder(observation_builder)
+
+    return observation_builder
+
+  def aggregated_list_resource(self, resource_type, **kwargs):
+    """Observe resources of a particular type."""
+    self.observer = GcpObjectObserver(
+        self.__gcp_agent.aggregated_list_resource, resource_type=resource_type,
+        **kwargs)
+    observation_builder = jc.ValueObservationVerifierBuilder(
+        'List Aggregated ' + resource_type, strict=self.__strict)
+    self.verifier_builder.append_verifier_builder(observation_builder)
+
+    return observation_builder
+
+  def inspect_resource(self, resource_type, resource_id, no_resource_ok=False,
+                       **kwargs):
+    """Observe the details of a specific instance.
+
+    Args:
+      resource_type: The gcp resource type  (e.g. instances)
+      resource_id: The GCP |resource| instance id
+      no_resource_ok: Whether or not the resource is required.
+          If the resource is not required, a 404 is treated as a valid check.
+          Because resource deletion is asynchronous, there is no explicit
+          API here to confirm that a resource does not exist.
+      kwargs: Additional parameters to pass to gcp_agent
+
+    Returns:
+      A js.ValueObservationVerifier that will collect the requested resource
+          when its verify() method is run.
+    """
+    self.observer = GcpObjectObserver(
+        self.__gcp_agent.get_resource,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        **kwargs)
+
+    if no_resource_ok:
+      error_verifier = GoogleAgentObservationFailureVerifier(
+          title='404 Permitted', http_code=404)
+      disjunction_builder = jc.ObservationVerifierBuilder(
+          'Inspect {0} {1} or 404'.format(resource_type, resource_id))
+      disjunction_builder.append_verifier(error_verifier)
+
+      inspect_builder = jc.ValueObservationVerifierBuilder(
+          'Inspect {0} {1}'.format(resource_type, resource_id),
+          strict=self.__strict)
+      disjunction_builder.append_verifier_builder(
+          inspect_builder, new_term=True)
+      self.verifier_builder.append_verifier_builder(
+          disjunction_builder, new_term=True)
+    else:
+      inspect_builder = jc.ValueObservationVerifierBuilder(
+          'Inspect {0} {1}'.format(resource_type, resource_id),
+          strict=self.__strict)
+      self.verifier_builder.append_verifier_builder(inspect_builder)
+
+    return inspect_builder
+
+
+class GcpContractBuilder(jc.ContractBuilder):
+  """Specialized contract that facilitates observing GCE."""
+
+  def __init__(self, gcp_agent, clause_factory=None):
+    """Constructs a new contract.
+
+    Args:
+      gcp_agent: [GcpAgent] The GcpAgent to use for communicating with GCE.
+      clause_factory: [factory creating a ContractClauseBuilder]
+    """
+    if clause_factory is None:
+      clause_factory = (
+          lambda title, retryable_for_secs=0, strict=False:
+              GcpClauseBuilder(title, gcp_agent=gcp_agent,
+                               retryable_for_secs=retryable_for_secs,
+                               strict=strict))
+    super(GcpContractBuilder, self).__init__(clause_factory)

--- a/citest/gcp_testing/gcp_error_predicates.py
+++ b/citest/gcp_testing/gcp_error_predicates.py
@@ -12,47 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Helper functions for creating authenticated GCP service clients."""
+"""Helper functions for verifying errors against Google API Clients."""
 
 
-import logging
 import re
 
-import httplib2
-
-from apiclient import discovery
 from googleapiclient.errors import HttpError
-from oauth2client.service_account import ServiceAccountCredentials
 
 from .. import json_contract as jc
 from .. import json_predicate as jp
-
-
-PLATFORM_READ_ONLY_SCOPE = (
-    'https://www.googleapis.com/auth/cloud-platform.read-only'
-    )
-PLATFORM_FULL_SCOPE = 'https://www.googleapis.com/auth/cloud-platform'
-
-
-def build_authenticated_service(name, version, scopes, credentials_path):
-  """Create an authenticated service client instance.
-
-  Args:
-    name: [String] The name of the service.
-    version: [String] The service API version.
-    scopes: [String] The credentials OAuth2 scopes.
-    credentials_path: [String] Path to JSON file containing GCP secrets.
-  Returns:
-    A Resource object with methods for interacting with the service.
-  """
-  logger = logging.getLogger(__name__)
-  logger.info('Authenticating %s %s', name, version)
-  credentials = ServiceAccountCredentials.from_json_keyfile_name(
-      credentials_path, scopes=scopes)
-
-  logger.info('Constructing %s service...', name)
-  http = credentials.authorize(httplib2.Http())
-  return discovery.build(name, version, http=http)
 
 
 class HttpErrorPredicateResult(jp.PredicateResult):
@@ -74,7 +42,7 @@ class HttpErrorPredicateResult(jp.PredicateResult):
   def export_to_json_snapshot(self, snapshot, entity):
     """Implements JsonSnapshotable interface."""
     builder = snapshot.edge_builder
-    builder.make_output('Error Value', self.__value)
+    builder.make_output(entity, 'Error Value', self.__value)
     super(HttpErrorPredicateResult, self).export_to_json_snapshot(snapshot,
                                                                   entity)
 

--- a/citest/gcp_testing/quota_predicate.py
+++ b/citest/gcp_testing/quota_predicate.py
@@ -16,7 +16,7 @@
 
 import logging
 
-from . import GceContractBuilder
+from .gce_contract import GceContractBuilder
 
 from ..base import (
     JournalLogger,
@@ -26,7 +26,6 @@ from ..json_predicate import (
     CompositePredicateResultBuilder,
     DONT_ENUMERATE_TERMINAL,
     NUM_GE,
-    NUM_LE,
     EQUIVALENT,
     FieldDifference,
     PathPredicate,

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
   license = 'APL2',
   install_requires = [
     "google-api-python-client",
+    "mock",
     "oauth2client",
     "pyyaml"
   ],

--- a/spinnaker/spinnaker_testing/spinnaker_test_scenario.py
+++ b/spinnaker/spinnaker_testing/spinnaker_test_scenario.py
@@ -153,6 +153,12 @@ class SpinnakerTestScenario(sk.AgentTestScenario):
              ' is GCE.')
 
     parser.add_argument(
+        '--gce_credentials_path',
+        default=defaults.get('GCE_CREDENTIALS_PATH', None),
+        help='A path to the JSON file with credentials to use for observing'
+             ' tests run against Google Cloud Platform.')
+
+    parser.add_argument(
         '--gce_ssh_passphrase_file',
         default=defaults.get('GCE_SSH_PASSPHRASE_FILE', None),
         help='Specifying a file containing the SSH passphrase'

--- a/tests/gcp_testing/gcp_agent_test.py
+++ b/tests/gcp_testing/gcp_agent_test.py
@@ -1,0 +1,197 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=missing-docstring
+
+import json
+import unittest
+from mock import patch, Mock
+from citest.gcp_testing.gcp_agent import GcpAgent
+
+def method_spec(parameterOrder, optional=None):
+    parameters = {key: {'required': True} for key in parameterOrder}
+    parameters.update({key: {} for key in optional or []})
+    return {'parameters': parameters, 'parameterOrder': parameterOrder}
+
+class TestAgent(GcpAgent):
+  @classmethod
+  def default_discovery_name_and_version(cls):
+    return  'TEST_API', 'TEST_VERSION'
+
+  @staticmethod
+  def generate_discovery_document(version='TEST_VERSION'):
+    if version != 'TEST_VERSION':
+        raise ValueError()
+    req = {'required': True}
+
+    return {
+        'title': 'MockCompute',
+        'name': 'mock-compute',
+        'resources' : {
+            'projects': {
+                'methods': {'get': method_spec(['project'])}},
+            'regions': {
+                'methods': {'get': method_spec(['project', 'region'])}},
+            'my_test': {
+                'methods': {'get': method_spec(['r'], ['o']),
+                            'list': method_spec([], ['o'])}}
+        }}
+
+
+class FakeDiscovery(object):
+  @property
+  def calls(self):
+    return self.__calls
+
+  def __init__(self, doc):
+    self.__doc = doc
+    self.__calls = []
+
+  def apis(self):
+    self.__calls.append('apis')
+    return self
+
+  def getRest(self, api, version):
+    self.__calls.append('getRest')
+    return self
+
+  def execute(self):
+    self.__calls.append('execute')
+    return self.__doc
+
+
+class FakeService(object):
+  @property
+  def calls(self):
+    return self.__calls
+
+  def __init__(self, execute_response_list):
+    self.__calls = []
+    self.__execute_response_list = list(execute_response_list)
+    self.__execute_response_list.reverse()
+    self.my_test = self._my_test  # needs to be a variable
+
+  def _my_test(self):
+    self.__calls.append('my_test')
+    return self
+
+  def get(self, **kwargs):
+    self.__calls.append('get({0})'.format(kwargs))
+    return self
+
+  def list(self, **kwargs):
+    self.__calls.append('list({0})'.format(kwargs))
+    return self
+
+  def execute(self):
+    self.__calls.append('execute')
+    return self.__execute_response_list.pop()
+
+  def list_next(self, request, response):
+    self.__calls.append('list_next')
+    return request if self.__execute_response_list else None
+
+      
+class GcpAgentTest(unittest.TestCase):
+  @patch('apiclient.discovery.build')
+  def test_download(self, mock_discovery):
+    doc = 'HELLO, WORLD!'
+    fake_discovery = FakeDiscovery(doc)
+    mock_discovery.return_value = fake_discovery
+    found = TestAgent.download_discovery_document()
+    self.assertEqual(doc, found)
+    self.assertEqual(['apis', 'getRest', 'execute'], fake_discovery.calls)
+
+  @patch('apiclient.discovery.build')
+  def test_make_agent(self, mock_discovery):
+    doc = TestAgent.generate_discovery_document()
+    fake_discovery = FakeDiscovery(doc)
+    mock_discovery.return_value = fake_discovery
+    agent = TestAgent.make_agent()
+
+    self.assertEqual(['apis', 'getRest', 'execute'], fake_discovery.calls)
+    self.assertEqual(doc, agent.discovery_document)
+    self.assertEqual({}, agent.default_variables)
+    
+  def test_resource_method_to_variables_no_defaults(self):
+    service = None
+    discovery_doc = TestAgent.generate_discovery_document()
+    agent = TestAgent(service, discovery_doc)
+
+    got = agent.resource_method_to_variables(
+        'get', 'my_test', r='R')
+    self.assertEqual({'r': 'R'}, got)
+
+    got = agent.resource_method_to_variables(
+        'get', 'my_test', r='R', o='O')
+    self.assertEqual({'r': 'R', 'o': 'O'}, got)
+
+    got = agent.resource_method_to_variables(
+        'get', 'my_test', resource_id='R')
+    self.assertEqual({'r': 'R'}, got)
+
+  def test_resource_method_to_variables_with_defaults(self):
+    service = None
+    discovery_doc = TestAgent.generate_discovery_document()
+    agent = TestAgent(service, discovery_doc,
+                      default_variables={'r': 'defR', 'o': 'defO'})
+    got = agent.resource_method_to_variables(
+        'get', 'my_test', r='R', o='O')
+    self.assertEqual({'r': 'R', 'o': 'O'}, got)
+
+    got = agent.resource_method_to_variables(
+        'get', 'my_test', r='R')
+    self.assertEqual({'r': 'R', 'o': 'defO'}, got)
+
+    got = agent.resource_method_to_variables(
+        'get', 'my_test', o='O')
+    self.assertEqual({'r': 'defR', 'o': 'O'}, got)
+
+    got = agent.resource_method_to_variables(
+        'get', 'my_test')
+    self.assertEqual({'r': 'defR', 'o': 'defO'}, got)
+
+    got = agent.resource_method_to_variables(
+        'get', 'my_test', o=None)
+    self.assertEqual({'r': 'defR'}, got)
+
+  def test_invoke(self):
+    doc = TestAgent.generate_discovery_document()
+    service = FakeService(['HELLO'])
+    agent = TestAgent(service, doc)
+
+    got = agent.invoke_resource('get', 'my_test', 'MY_ID')
+    args = {'r': 'MY_ID'}
+    self.assertEqual(['my_test', 'get({0})'.format(args), 'execute'],
+                     service.calls)
+    self.assertEqual('HELLO', got)
+
+  def test_list(self):
+    doc = TestAgent.generate_discovery_document()
+    service = FakeService([{'items': [1, 2, 3]},
+                           {'items': [4, 5, 6]}])
+    agent = TestAgent(service, doc)
+
+    got = agent.list_resource('my_test')
+    self.assertEqual(['my_test', 'list({})', 'execute',
+                      'list_next', 'execute', 'list_next'],
+                     service.calls)
+    self.assertEqual([1, 2, 3, 4, 5, 6], got)
+
+
+if __name__ == '__main__':
+  # pylint: disable=invalid-name
+  loader = unittest.TestLoader()
+  suite = loader.loadTestsFromTestCase(GcpAgentTest)
+  unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
This is two PRs combined together since it's slightly less than individually.

The first introduces a GcpAgent as an alternative to GCloudAgent. It needs to be specialized in practice, but only because it gets the API name from the class rather than a parameter to make the API slightly simpler. In practice different APIs might have additional specialized methods anyway. Github might not make this clear, but the old "gcp_api.py" was moved to "gcp_error_predicates.py" and the factory functions for an agent were refactored into the new gcp_agent.py.

Using the client APIs rather than GCloud gives more flexibility and generalizes more to APIs without gcloud support (e.g. kubernetes). Plus wont require the google cloud SDK installed to run citest (e.g. testing GCP from AWS).

The second PR refactors the GoogleCloudStorageAgent to use GcpAgent.

A followup PR will introduce GcpComputeAgent and refactor the spinnaker tests to use that. GCloudAgent is still used for remote commands and port tunelling.

@jtk54 