### PR TITLE
Remove AgentTestCase's dependency on TestRunner.

### DIFF
--- a/citest/service_testing/agent_test_case.py
+++ b/citest/service_testing/agent_test_case.py
@@ -36,11 +36,13 @@ import time
 import traceback as traceback_module
 
 # Our modules.
-from ..base import args_util
-from ..base import BaseTestCase
-from ..base import JournalLogger
-from ..base import JsonSnapshotableEntity
-from ..base import TestRunner
+
+from ..base import (
+    args_util,
+    BaseTestCase,
+    JournalLogger,
+    JsonSnapshotableEntity,
+    TestRunner)
 
 
 _DEFAULT_TEST_ID = time.strftime('%H%M%S')
@@ -319,7 +321,7 @@ class AgentTestCase(BaseTestCase):
 
   def report(self, obj):
     """Write the object state into the test report."""
-    TestRunner.global_runner().report(obj)
+    JournalLogger.store_or_log(obj)
 
   @property
   def scenario(self):

--- a/tests/service_testing/agent_test_case_test.py
+++ b/tests/service_testing/agent_test_case_test.py
@@ -1,0 +1,117 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=missing-docstring
+# pylint: disable=invalid-name
+
+import unittest
+
+import citest.service_testing.agent_test_case as agent_test_case
+import citest.service_testing as st
+import citest.json_contract as jc
+
+
+from .fake_agent import (
+    FakeAgent,
+    FakeOperation,
+    FakeStatus)
+
+
+class FakeObserver(jc.ObjectObserver):
+  def collect_observation(self, observation, trace=True):
+    pass
+
+
+class FakeVerifier(jc.ObservationVerifier):
+  def __init__(self, valid):
+    super(FakeVerifier, self).__init__('TestVerifier')
+    self.__valid = valid
+
+  def __call__(self, observation):
+    return jc.ObservationVerifyResult(
+        valid=self.__valid, observation=observation,
+        good_results=[], bad_results=[], failed_constraints=[])
+
+
+class AgentTestCaseTest(st.AgentTestCase):
+  def setUp(self):
+    self.testing_agent = FakeAgent()
+
+  def test_raise_final_status_not_ok(self):
+    attempt = agent_test_case.OperationContractExecutionAttempt('TestOp')
+    operation = st.AgentOperation('TestStatus', agent=self.testing_agent)
+    status = FakeStatus(operation)
+    self.assertRaises(
+        AssertionError,
+        self.raise_final_status_not_ok, status, attempt)
+
+  def test_assertContract_ok(self):
+    verifier = FakeVerifier(True)
+    clause = jc.ContractClause(
+        'TestClause', observer=FakeObserver(), verifier=verifier)
+    contract = jc.Contract()
+    contract.add_clause(clause)
+    self.assertContract(contract)
+
+  def test_assertContract_failed(self):
+    verifier = FakeVerifier(False)
+    clause = jc.ContractClause(
+        'TestClause', observer=FakeObserver(), verifier=verifier)
+    contract = jc.Contract()
+    contract.add_clause(clause)
+    self.assertRaises(AssertionError, self.assertContract, contract)
+
+  def test_assertVerifyResults_ok(self):
+    observation = jc.Observation()
+    verify_results = jc.ObservationVerifyResult(
+        valid=True, observation=observation,
+        good_results=[], bad_results=[], failed_constraints=[])
+    self.assertVerifyResults(verify_results)
+
+  def test_assertVerifyResults_failed(self):
+    observation = jc.Observation()
+    verify_results = jc.ObservationVerifyResult(
+        valid=False, observation=observation,
+        good_results=[], bad_results=[], failed_constraints=[])
+    self.assertRaises(AssertionError, self.assertVerifyResults, verify_results)
+
+  def test_run_test_case_ok(self):
+    operation = FakeOperation('TestOperation', self.testing_agent)
+
+    verifier = FakeVerifier(True)
+    clause = jc.ContractClause(
+        'TestClause', observer=FakeObserver(), verifier=verifier)
+    contract = jc.Contract()
+    contract.add_clause(clause)
+
+    operation_contract = st.OperationContract(operation, contract)
+    self.run_test_case(operation_contract)
+
+  def test_run_test_case_failed(self):
+    operation = FakeOperation('TestOperation', self.testing_agent)
+
+    verifier = FakeVerifier(False)
+    clause = jc.ContractClause(
+        'TestClause', observer=FakeObserver(), verifier=verifier)
+    contract = jc.Contract()
+    contract.add_clause(clause)
+
+    operation_contract = st.OperationContract(operation, contract)
+    self.assertRaises(AssertionError, self.run_test_case, operation_contract)
+
+
+if __name__ == '__main__':
+  loader = unittest.TestLoader()
+  suite = loader.loadTestsFromTestCase(AgentTestCaseTest)
+  unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/service_testing/base_agent_test.py
+++ b/tests/service_testing/base_agent_test.py
@@ -16,65 +16,9 @@
 import unittest
 import citest.service_testing as st
 
-
-class FakeAgent(st.BaseAgent):
-   @property
-   def time_series(self):
-      return self._time_series
-
-   @time_series.setter
-   def time_series(self, time_series):
-      self._time_series = time_series
-
-   def next_time(self):
-     next_time = self._time_series[0]
-     self._time_series = self._time_series[1:]
-     return next_time
-      
-   def __init__(self, time_series=None):
-     super(FakeAgent, self).__init__()
-     self._time_series = time_series or [0] * 100
-
-
-class FakeStatus(st.AgentOperationStatus):
-  @property
-  def id(self):
-    return "test-id"
-
-  @property
-  def finished(self):
-    return self.__finished
-
-  @property
-  def finished_ok(self):
-     return self.__finished
-
-  def __init__(self, operation):
-    super(FakeStatus, self).__init__(operation)
-    self.__finished = False
-    self.calls_remaining = 0
-    self.got_refresh_count = 0
-    self.got_sleep_count = 0
-
-  def set_expected_iterations(self, n):
-    self.__finished = False
-    self.calls_remaining = n
-    self.got_refresh_count = 0
-    self.got_sleep_count = 0
-
-  def _now(self):
-     return self.operation.agent.next_time()
-
-  def _do_sleep(self, secs):
-    self.got_sleep_secs = secs
-    self.got_sleep_count += 1
-
-  def refresh(self, trace):
-    self.got_refresh_count += 1
-    if self.calls_remaining >= 0:
-      self.calls_remaining -= 1
-      if self.calls_remaining < 0:
-        self.__finished = True
+from .fake_agent import (
+    FakeAgent,
+    FakeStatus)
 
 
 class BaseAgentTest(unittest.TestCase):

--- a/tests/service_testing/fake_agent.py
+++ b/tests/service_testing/fake_agent.py
@@ -1,0 +1,100 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=missing-docstring
+
+"""Helper classes for writing unit tests."""
+
+import citest.service_testing as st
+
+
+class FakeAgent(st.BaseAgent):
+  """Fake agents dont do anything other than manage time for wait loops."""
+
+  @property
+  def time_series(self):
+    return self._time_series
+
+  @time_series.setter
+  def time_series(self, time_series):
+    self._time_series = time_series
+
+  def next_time(self):
+    next_time = self._time_series[0]
+    self._time_series = self._time_series[1:]
+    return next_time
+
+  def __init__(self, time_series=None):
+    super(FakeAgent, self).__init__()
+    self._time_series = time_series or [0] * 100
+
+
+class FakeStatus(st.AgentOperationStatus):
+  """Fake status dont do anything other than count calls."""
+
+  @property
+  def timed_out(self):
+    return self.__timed_out
+
+  @property
+  def detail(self):
+    return 'Fake Detail'
+
+  @property
+  def id(self):
+    return 'test-id'
+
+  @property
+  def finished(self):
+    return self.__finished
+
+  @property
+  def finished_ok(self):
+    return self.__finished
+
+  def __init__(self, operation):
+    super(FakeStatus, self).__init__(operation)
+    self.__finished = False
+    self.__timed_out = False
+    self.calls_remaining = 0
+    self.got_refresh_count = 0
+    self.got_sleep_count = 0
+    self.got_sleep_secs = None
+
+  def set_expected_iterations(self, num):
+    self.__finished = False
+    self.calls_remaining = num
+    self.got_refresh_count = 0
+    self.got_sleep_count = 0
+
+  def _now(self):
+    return self.operation.agent.next_time()
+
+  def _do_sleep(self, secs):
+    self.got_sleep_secs = secs
+    self.got_sleep_count += 1
+
+  def refresh(self, trace=True):
+    self.got_refresh_count += 1
+    if self.calls_remaining >= 0:
+      self.calls_remaining -= 1
+      if self.calls_remaining < 0:
+        self.__finished = True
+
+
+class FakeOperation(st.AgentOperation):
+  """Fake operation doesnt do anything other than return a fake status."""
+
+  def execute(self, agent=None):
+    return FakeStatus(self)


### PR DESCRIPTION
Dependency was only for storing objects in the journal.
Since it is already using JournalLogger, and store only forwards to the
global runner's logger, it asks the JournalLogger to store the object instead.

Also added test for AgentTestCase.

@jtk54 