### PR TITLE
Make JsonSnapshotable a bit more generic.

### DIFF
--- a/citest/aws_testing/aws_agent.py
+++ b/citest/aws_testing/aws_agent.py
@@ -57,7 +57,7 @@ class AwsAgent(st.CliAgent):
     self.logger = logging.getLogger(__name__)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     builder = snapshot.edge_builder
     builder.make_control(entity, 'Profile', self.__profile)
     builder.make_control(entity, 'Region', self.__region)

--- a/citest/base/__init__.py
+++ b/citest/base/__init__.py
@@ -15,6 +15,7 @@
 
 from snapshot import (
     JsonSnapshotable,
+    JsonSnapshotableEntity,
     JsonSnapshotHelper,
     JsonSnapshot,
     Edge,

--- a/citest/base/journal.py
+++ b/citest/base/journal.py
@@ -151,7 +151,7 @@ class Journal(object):
       metadata: [kwargs] Additional metadata for the entry.
     """
     snapshot = JsonSnapshot(**metadata)
-    snapshot.add_data(obj)
+    snapshot.add_object(obj)
     self.__write_json_object(snapshot.to_json_object())
 
   def _do_close(self):

--- a/citest/base/test_runner.py
+++ b/citest/base/test_runner.py
@@ -36,7 +36,7 @@ import unittest
 # Our modules.
 from . import global_journal
 from . import args_util
-from .snapshot import JsonSnapshotable
+from .snapshot import JsonSnapshotableEntity
 
 # If a -log_config is not provided, then use this.
 _DEFAULT_LOG_CONFIG = """{
@@ -333,7 +333,7 @@ class TestRunner(object):
     Args:
       obj: The object to write into the report.
     """
-    if isinstance(obj, JsonSnapshotable):
+    if isinstance(obj, JsonSnapshotableEntity):
       self.__journal.store(obj)
     else:
       raise '{0} is not JsonSnashotable\n{1}'.format(type(obj), obj)

--- a/citest/gcp_testing/__init__.py
+++ b/citest/gcp_testing/__init__.py
@@ -16,10 +16,15 @@
 """Citest support modules for testing against Google Cloud Platform (GCP)."""
 
 
-from gcloud_agent import GCloudAgent
+from gcp_agent import GcpAgent
+from gcp_contract import GcpContractBuilder
 
-from gcloud_contract import GceContractBuilder # DEPRECATED
-
+from gcp_compute_agent import (
+    COMPUTE_FULL_SCOPE,
+    COMPUTE_READ_ONLY_SCOPE,
+    COMPUTE_READ_WRITE_SCOPE,
+    GcpComputeAgent)
+    
 from gcp_storage_agent import (
     GcpStorageAgent,
     STORAGE_FULL_SCOPE,
@@ -28,19 +33,13 @@ from gcp_storage_agent import (
     
 from gcp_storage_contract import GcpStorageContractBuilder
 
+from gcloud_agent import GCloudAgent
+from gcloud_contract import GCloudContractBuilder
+
 from quota_predicate import (
     QuotaPredicate,
     make_quota_contract,
     verify_quota)
-
-from gcp_agent import GcpAgent
-from gcp_compute_agent import (
-    COMPUTE_FULL_SCOPE,
-    COMPUTE_READ_ONLY_SCOPE,
-    COMPUTE_READ_WRITE_SCOPE,
-    GcpComputeAgent)
-    
-from gcp_contract import GcpContractBuilder
 
 from gcp_error_predicates import (
     GoogleAgentObservationFailureVerifier,

--- a/citest/gcp_testing/gcloud_agent.py
+++ b/citest/gcp_testing/gcloud_agent.py
@@ -184,7 +184,7 @@ class GCloudAgent(cli_agent.CliAgent):
     return super(GCloudAgent, self)._args_to_full_commandline(args)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     builder = snapshot.edge_builder
     builder.make_control(entity, 'Project', self.__project)
     builder.make_control(entity, 'Zone', self.__zone)

--- a/citest/gcp_testing/gcloud_contract.py
+++ b/citest/gcp_testing/gcloud_contract.py
@@ -40,7 +40,7 @@ class GCloudObjectObserver(jc.ObjectObserver):
     self.__args = args
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_control(entity, 'Args', self.__args)
     super(GCloudObjectObserver, self).export_to_json_snapshot(snapshot, entity)
 

--- a/citest/gcp_testing/gcp_contract.py
+++ b/citest/gcp_testing/gcp_contract.py
@@ -43,7 +43,7 @@ class GcpObjectObserver(jc.ObjectObserver):
     self.__kwargs = dict(kwargs)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_control(entity, 'Args', self.__kwargs)
     super(GcpObjectObserver, self).export_to_json_snapshot(snapshot, entity)
 

--- a/citest/gcp_testing/gcp_error_predicates.py
+++ b/citest/gcp_testing/gcp_error_predicates.py
@@ -40,7 +40,7 @@ class HttpErrorPredicateResult(jp.PredicateResult):
             and self.__value == result.value)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     builder = snapshot.edge_builder
     builder.make_output(entity, 'Error Value', self.__value)
     super(HttpErrorPredicateResult, self).export_to_json_snapshot(snapshot,
@@ -103,7 +103,7 @@ class HttpErrorPredicate(jp.ValuePredicate):
     return HttpErrorPredicateResult(True, value, comment=' '.join(message))
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     if self.__http_code:
       snapshot.edge_builder.make_control(entity, 'HTTP Code', self.__http_code)
     if self.__content_regex:
@@ -140,7 +140,7 @@ class GoogleAgentObservationFailureVerifier(jc.ObservationVerifier):
     self.__pred = HttpErrorPredicate(http_code, content_regex)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_control(entity, 'Expect', self.__pred)
     super(GoogleAgentObservationFailureVerifier, self).export_to_json_snapshot(
         snapshot, entity)

--- a/citest/gcp_testing/quota_predicate.py
+++ b/citest/gcp_testing/quota_predicate.py
@@ -140,7 +140,7 @@ class QuotaPredicate(ValuePredicate):
     return builder.build(valid)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_control(
         entity, 'Minimum', self.__minimum_quota)
 

--- a/citest/json_contract/contract.py
+++ b/citest/json_contract/contract.py
@@ -27,7 +27,7 @@ import logging
 import time
 
 from ..base import JournalLogger
-from ..base import JsonSnapshotable
+from ..base import JsonSnapshotableEntity
 from ..json_predicate import predicate
 from . import observer as ob
 from . import observation_verifier as ov
@@ -89,7 +89,7 @@ class ContractClauseVerifyResult(predicate.PredicateResult):
         self.__clause, self.__verify_results)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     builder = snapshot.edge_builder
     entity.add_metadata('_title',
                         'Verification of "{0}"'.format(self.__clause.title))
@@ -126,7 +126,7 @@ class ContractClause(predicate.ValuePredicate):
         super(ContractClause, self).__repr__(), self.__title, self.__verifier)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     entity.add_metadata('_title', self.__title)
     snapshot.edge_builder.make(entity, 'Title', self.__title)
     snapshot.edge_builder.make_mechanism(entity, 'Observer', self.__observer)
@@ -348,14 +348,14 @@ class ContractVerifyResult(predicate.PredicateResult):
         super(ContractVerifyResult, self).__repr__(), self.__clause_results)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     relation = snapshot.edge_builder.determine_valid_relation(self)
     snapshot.edge_builder.make(
         entity, 'Clause Results', self.__clause_results, relation=relation)
     super(ContractVerifyResult, self).export_to_json_snapshot(snapshot, entity)
 
 
-class Contract(JsonSnapshotable):
+class Contract(JsonSnapshotableEntity):
   """A contract holds a collection of ContractClause.
 
   Attributes:
@@ -370,7 +370,7 @@ class Contract(JsonSnapshotable):
     self.__clauses = []
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_control(entity, 'Clauses', self.__clauses)
 
   def add_clause(self, clause):

--- a/citest/json_contract/observation_failure.py
+++ b/citest/json_contract/observation_failure.py
@@ -39,7 +39,7 @@ class ObservationFailedError(predicate.PredicateResult):
     self.__failures = failures
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     super(ObservationFailedError, self).export_to_json_snapshot(
         snapshot, entity)
     snapshot.edge_builder.make(entity, 'Failures', self.__failures)

--- a/citest/json_contract/observation_verifier.py
+++ b/citest/json_contract/observation_verifier.py
@@ -18,7 +18,7 @@
 
 import logging
 
-from ..base import JsonSnapshotable
+from ..base import JsonSnapshotableEntity
 from ..json_predicate import map_predicate
 from ..json_predicate import predicate
 
@@ -196,7 +196,7 @@ class ObservationVerifyResult(predicate.PredicateResult):
     self.__failed_constraints = failed_constraints
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     super(ObservationVerifyResult, self).export_to_json_snapshot(
         snapshot, entity)
     builder = snapshot.edge_builder
@@ -241,7 +241,7 @@ class ObservationVerifier(predicate.ValuePredicate):
     return self.__title
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     entity.add_metadata('_title', self.__title)
     disjunction = self.__dnf_verifiers
     builder = snapshot.edge_builder
@@ -255,7 +255,7 @@ class ObservationVerifier(predicate.ValuePredicate):
       if len(conjunction) == 1:
         # A special case to optimize the report to remove the conjunction
         # wrapper since there is only one component anyway
-        all_conjunctions.append(snapshot.make_entity_for_data(conjunction[0]))
+        all_conjunctions.append(snapshot.make_entity_for_object(conjunction[0]))
       else:
         conjunction_entity = snapshot.new_entity(summary='AND predicates')
         builder.make(
@@ -338,7 +338,7 @@ class _VerifierBuilderWrapper(object):
     return self.__verifier
 
 
-class ObservationVerifierBuilder(JsonSnapshotable):
+class ObservationVerifierBuilder(JsonSnapshotableEntity):
   @property
   def title(self):
     return self.__title
@@ -367,7 +367,7 @@ class ObservationVerifierBuilder(JsonSnapshotable):
     self.__current_builder = None
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     entity.add_metadata('_title', self.__title)
     snapshot.edge_builder.make(entity, 'Title', self.__title)
     snapshot.edge_builder.make(

--- a/citest/json_contract/observer.py
+++ b/citest/json_contract/observer.py
@@ -16,9 +16,9 @@
 """Observers make observations that are a collection of data to be verified."""
 
 
-from ..base import JsonSnapshotable
+from ..base import JsonSnapshotableEntity
 
-class Observation(JsonSnapshotable):
+class Observation(JsonSnapshotableEntity):
   """Tracks details for ObjectObserver and ObservationVerifier."""
 
   @property
@@ -36,7 +36,7 @@ class Observation(JsonSnapshotable):
     self.__errors = []
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     builder = snapshot.edge_builder
     edge = builder.make(entity, 'Errors', self.__errors)
     if self.__errors:
@@ -119,7 +119,7 @@ class Observation(JsonSnapshotable):
     return True
 
 
-class ObjectObserver(JsonSnapshotable):
+class ObjectObserver(JsonSnapshotableEntity):
   """Acts as an object source to feed objects into a contract.
 
   This class requires specialization for specific sources.
@@ -133,7 +133,7 @@ class ObjectObserver(JsonSnapshotable):
     return self.__filter
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_mechanism(entity, 'Filter', self.__filter)
 
   def __init__(self, filter=None):

--- a/citest/json_contract/value_observation_verifier.py
+++ b/citest/json_contract/value_observation_verifier.py
@@ -54,7 +54,7 @@ class ValueObservationVerifierBuilder(ov.ObservationVerifierBuilder):
         strict=self.__strict)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_control(entity, 'Strict', self.__strict)
     if len(self.__constraints) == 1:
       # Optimize model for single-element list
@@ -127,7 +127,7 @@ class ValueObservationVerifier(ov.ObservationVerifier):
     return self.__strict
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_control(entity, 'Strict', self.__strict)
     snapshot.edge_builder.make_control(
         entity, 'Constraints', self.__constraints)

--- a/citest/json_predicate/binary_predicate.py
+++ b/citest/json_predicate/binary_predicate.py
@@ -62,7 +62,7 @@ class BinaryPredicate(predicate.ValuePredicate):
             and self.__operand == pred.operand)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make(entity, 'Name', self.__name)
     snapshot.edge_builder.make_control(entity, 'Operand', self.__operand)
 

--- a/citest/json_predicate/cardinality_predicate.py
+++ b/citest/json_predicate/cardinality_predicate.py
@@ -98,7 +98,7 @@ class CardinalityResult(predicate.PredicateResult, HasPathPredicateResult):
             and self.__collect_values_result == event.path_predicate_result)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     builder = snapshot.edge_builder
     count_relation = builder.determine_valid_relation(self)
     result_relation = builder.determine_valid_relation(
@@ -214,7 +214,7 @@ class CardinalityPredicate(predicate.ValuePredicate,
     return self.__max
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_mechanism(entity, 'Predicate', self.path_pred)
     snapshot.edge_builder.make_control(entity, 'Min', self.__min)
     snapshot.edge_builder.make_control(entity, 'Max',

--- a/citest/json_predicate/json_error.py
+++ b/citest/json_predicate/json_error.py
@@ -16,14 +16,14 @@
 """Common errors the the citest.json_contract package."""
 
 
-from ..base import JsonSnapshotable
+from ..base import JsonSnapshotableEntity
 
 
-class JsonError(ValueError, JsonSnapshotable):
+class JsonError(ValueError, JsonSnapshotableEntity):
   """Denotes an error relatived to invalid JSON."""
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make(entity, 'Message', self.message)
     if self.__cause:
       snapshot.edge_builder.make(entity, 'CausedBy', str(self.__cause))

--- a/citest/json_predicate/logic_predicate.py
+++ b/citest/json_predicate/logic_predicate.py
@@ -44,7 +44,7 @@ class ConjunctivePredicate(predicate.ValuePredicate):
             and self.predicates == pred.predicates)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make(entity, 'Conjunction', self.__conjunction,
                                join='AND')
 
@@ -87,7 +87,7 @@ class DisjunctivePredicate(predicate.ValuePredicate):
     self.__disjunction.append(pred)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make(entity, 'Disjunction', self.__disjunction,
                                join='OR')
 
@@ -126,7 +126,7 @@ class NegationPredicate(predicate.ValuePredicate):
             and self.__pred == other.predicate)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_mechanism(entity, 'Predicate', self.__pred)
 
   def __call__(self, value):
@@ -193,7 +193,7 @@ class ConditionalPredicate(predicate.ValuePredicate):
             and self.__else_pred == other.else_predicate)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_mechanism(entity, 'If', self.__if_pred)
     snapshot.edge_builder.make_mechanism(entity, 'Then', self.__then_pred)
     if self.__else_pred:

--- a/citest/json_predicate/map_predicate.py
+++ b/citest/json_predicate/map_predicate.py
@@ -17,13 +17,13 @@
 
 import collections
 
-from ..base import JsonSnapshotable
+from ..base import JsonSnapshotableEntity
 from . import predicate
 
 
 class ObjectResultMapAttempt(
     collections.namedtuple('ObjectResultMapAttempt', ['obj', 'result']),
-    JsonSnapshotable):
+    JsonSnapshotableEntity):
   """Holds a individual value and its result."""
 
   @property
@@ -40,7 +40,7 @@ class ObjectResultMapAttempt(
             and self.result == attempt.result)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     builder = snapshot.edge_builder
     result_summary = '{name} {valid}'.format(
         name=self.obj.__class__.__name__, valid=self.result.valid)
@@ -117,7 +117,7 @@ class MapPredicateResult(predicate.CompositePredicateResult):
     return attempt_entity
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     func = lambda l: [self.__map_attempt_to_entity(e, snapshot) for e in l]
     builder = snapshot.edge_builder
     builder.make_input(entity, 'Object List', self.__obj_list,
@@ -213,7 +213,7 @@ class MapPredicate(predicate.ValuePredicate):
         bad_map=bad_map)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     builder = snapshot.edge_builder
     builder.make_mechanism(entity, 'Mapped Predicate', self.__pred,
                            summary=self.__pred.__class__)

--- a/citest/json_predicate/path_predicate.py
+++ b/citest/json_predicate/path_predicate.py
@@ -248,7 +248,7 @@ class PathPredicate(ValuePredicate, ProducesPathPredicateResult):
     return self.__transform
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_control(entity, 'Path', self.__path)
     snapshot.edge_builder.make_mechanism(entity, 'Predicate', self.__pred)
     if self.__transform:

--- a/citest/json_predicate/path_predicate_result.py
+++ b/citest/json_predicate/path_predicate_result.py
@@ -16,19 +16,19 @@
 
 
 import collections
-from ..base import JsonSnapshotable
+from ..base import JsonSnapshotableEntity
 from . import predicate
 
 
 class PathPredicateResultCandidate(
     collections.namedtuple('PathPredicateResultCandidate',
                            ['path_value', 'result']),
-    JsonSnapshotable):
+    JsonSnapshotableEntity):
   """Holds a value matching the desired path with its filtering result."""
   # pylint: disable=too-few-public-methods
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_output(
         entity, 'Path Value', self.path_value)
     snapshot.edge_builder.make_output(
@@ -226,7 +226,7 @@ class PathPredicateResult(predicate.PredicateResult, HasPathPredicateResult):
             and self.__path_failures == result.path_failures)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_mechanism(entity, 'Predicate', self.__pred)
     # Separate out just the path values from the full justification (below)
     # to make it easy to get at the list of values found, which is often

--- a/citest/json_predicate/path_result.py
+++ b/citest/json_predicate/path_result.py
@@ -54,7 +54,7 @@ class PathResult(PredicateResult, CloneableWithContext):
     return self.__source
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     builder = snapshot.edge_builder
     builder.make_control(entity, 'Target Path', self.__target_path)
     builder.make_input(entity, 'Source', self.__source, format='json')
@@ -152,7 +152,7 @@ class PathValueResult(PathResult):
         comment=self.comment, cause=self.cause)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     builder = snapshot.edge_builder
     if self.__pred:
       builder.make_control(entity, 'Filter', self.__pred)

--- a/citest/json_predicate/path_transforms.py
+++ b/citest/json_predicate/path_transforms.py
@@ -14,10 +14,10 @@
 
 """Common transforms to use with PathPredicate that provide journaling."""
 
-from ..base import JsonSnapshotable
+from ..base import JsonSnapshotableEntity
 from .path_value import PATH_SEP
 
-class FieldDifference(JsonSnapshotable):
+class FieldDifference(JsonSnapshotableEntity):
   """Transform a dictionary value into the difference of two fields within."""
 
   @property
@@ -54,7 +54,7 @@ class FieldDifference(JsonSnapshotable):
             and self.__subtractend == transform.subtractend)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_control(
         entity, 'Operation',
         '{0} - {1}'.format(self.__minuend, self.__subtractend))

--- a/citest/json_predicate/path_value.py
+++ b/citest/json_predicate/path_value.py
@@ -16,7 +16,7 @@
 """Track the accumulation of Path/Value pairs found."""
 
 import collections
-from ..base import JsonSnapshotable
+from ..base import JsonSnapshotableEntity
 
 # Denotes the seperator used when specifying paths to JSON attributes
 # in an object hierarchy.
@@ -24,7 +24,7 @@ PATH_SEP = '/'
 
 
 class PathValue(collections.namedtuple('PathValue', ['path', 'value']),
-                JsonSnapshotable):
+                JsonSnapshotableEntity):
   """A path, value pair.
 
   Attributes:
@@ -36,7 +36,7 @@ class PathValue(collections.namedtuple('PathValue', ['path', 'value']),
     return '"{0}"={1!r}'.format(self.path, self.value)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_control(entity, 'Path', self.path)
     snapshot.edge_builder.make_data(entity, 'Value', self.value,
                                     format='json')

--- a/citest/json_predicate/predicate.py
+++ b/citest/json_predicate/predicate.py
@@ -15,10 +15,10 @@
 """Implements ValuePredicate that determines when a given value is 'valid'."""
 
 
-from ..base import JsonSnapshotable
+from ..base import JsonSnapshotableEntity
 
 
-class ValuePredicate(JsonSnapshotable):
+class ValuePredicate(JsonSnapshotableEntity):
   """Base class denoting a predicate that determines if a JSON value is ok.
 
    This class must be specialized with a __call__ method that takes a single
@@ -51,7 +51,7 @@ class ValuePredicate(JsonSnapshotable):
     return not self.__eq__(pred)
 
 
-class PredicateResult(JsonSnapshotable):
+class PredicateResult(JsonSnapshotableEntity):
   """Base class for predicate results.
 
   Attributes:
@@ -85,7 +85,7 @@ class PredicateResult(JsonSnapshotable):
     return self.__valid
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     builder = snapshot.edge_builder
     verified_relation = builder.determine_valid_relation(self.__valid)
     builder.make(entity, 'Valid', self.__valid, relation=verified_relation)

--- a/citest/kube_testing/kube_contract.py
+++ b/citest/kube_testing/kube_contract.py
@@ -40,7 +40,7 @@ class KubeObjectObserver(jc.ObjectObserver):
     self.__args = args
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_control(entity, 'Args', self.__args)
     super(KubeObjectObserver, self).export_to_json_snapshot(snapshot, entity)
 

--- a/citest/service_testing/agent_test_case.py
+++ b/citest/service_testing/agent_test_case.py
@@ -39,7 +39,7 @@ import traceback as traceback_module
 from ..base import args_util
 from ..base import BaseTestCase
 from ..base import JournalLogger
-from ..base import JsonSnapshotable
+from ..base import JsonSnapshotableEntity
 from ..base import TestRunner
 
 
@@ -50,7 +50,7 @@ _DEFAULT_TEST_ID = time.strftime('%H%M%S')
 _DURATION_PRECISION = 3  # millis
 
 
-class OperationContractExecutionAttempt(JsonSnapshotable):
+class OperationContractExecutionAttempt(JsonSnapshotableEntity):
   """Represents an individual attempt at running an OperationContract test case.
 
   This class captures the attempt and results so that it can be recorded in
@@ -114,7 +114,7 @@ class OperationContractExecutionAttempt(JsonSnapshotable):
     self.__status_summary = summary
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     builder = snapshot.edge_builder
     default_relation = self.default_relation
     if default_relation  is not None:
@@ -148,7 +148,7 @@ class OperationContractExecutionAttempt(JsonSnapshotable):
         edge.add_metadata('summary', self.__verification_summary)
 
 
-class OperationContractExecutionTrace(JsonSnapshotable):
+class OperationContractExecutionTrace(JsonSnapshotableEntity):
   """Represents the execution and evaluation of an OperationContract test case.
   """
 
@@ -194,7 +194,7 @@ class OperationContractExecutionTrace(JsonSnapshotable):
     return attempt
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     entity.add_metadata('_title', self.__test_case.operation.title)
 
     builder = snapshot.edge_builder

--- a/citest/service_testing/base_agent.py
+++ b/citest/service_testing/base_agent.py
@@ -31,15 +31,15 @@ import sys
 import time
 
 from ..base import JsonScrubber
-from ..base import JsonSnapshotable
+from ..base import JsonSnapshotableEntity
 from ..base import JournalLogger
 
 
-class AgentError(Exception, JsonSnapshotable):
+class AgentError(Exception, JsonSnapshotableEntity):
   """Denotes an error reported by a BaseAgent."""
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_error(entity, 'Message', self.message)
 
   def __init__(self, message):
@@ -53,7 +53,7 @@ class AgentError(Exception, JsonSnapshotable):
             and self.message == error.message)
 
 
-class BaseAgent(JsonSnapshotable):
+class BaseAgent(JsonSnapshotableEntity):
   """Base class for adapting services and observers into the citest framework.
 
   The base class does not introduce any significant behavior, but the intent
@@ -103,7 +103,7 @@ class BaseAgent(JsonSnapshotable):
     builder.make_control(entity, 'Configuration', scrubbed_config)
 
 
-class AgentOperationStatus(JsonSnapshotable):
+class AgentOperationStatus(JsonSnapshotableEntity):
   """Base class for current Status on AgentOperation.
 
   The operations performed by base agents have disparate results depending
@@ -175,7 +175,7 @@ class AgentOperationStatus(JsonSnapshotable):
     return self.__operation.agent
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     builder = snapshot.edge_builder
     builder.make(entity, 'ID', self.id)
     builder.make_output(entity, 'Finished', self.finished)
@@ -298,7 +298,7 @@ class AgentOperationStatus(JsonSnapshotable):
     time.sleep(secs)
 
 
-class AgentOperation(JsonSnapshotable):
+class AgentOperation(JsonSnapshotableEntity):
   """Base class abstraction for a testable operation executed through an agent.
 
   AgentOperation is a first-class operation that can be executed at some point
@@ -357,7 +357,7 @@ class AgentOperation(JsonSnapshotable):
     self.__max_wait_secs = max_wait_secs
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     builder = snapshot.edge_builder
     builder.make(entity, 'Title', self.title)
     builder.make_mechanism(

--- a/citest/service_testing/cli_agent.py
+++ b/citest/service_testing/cli_agent.py
@@ -18,14 +18,14 @@ import re
 import subprocess
 
 from ..base import JournalLogger
-from ..base import JsonSnapshotable
+from ..base import JsonSnapshotableEntity
 from .. import json_contract as jc
 from . import base_agent
 
 
 class CliResponseType(collections.namedtuple('CliResponseType',
                                              ['exit_code', 'output', 'error']),
-                      JsonSnapshotable):
+                      JsonSnapshotableEntity):
   """Holds the results from running the command-line program.
 
   Attributes:
@@ -42,7 +42,7 @@ class CliResponseType(collections.namedtuple('CliResponseType',
         self.exit_code, self.output, self.error)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     builder = snapshot.edge_builder
     builder.make(entity, 'Exit Code', self.exit_code)
     if self.error:
@@ -102,7 +102,7 @@ class CliAgentRunError(base_agent.AgentError):
     return self.__run_response
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     super(CliAgentRunError, self).export_to_json_snapshot(snapshot, entity)
     snapshot.edge_builder.make_data(
         entity, 'Cli Response', self.__run_response)
@@ -140,7 +140,7 @@ class CliAgent(base_agent.BaseAgent):
     self.__output_scrubber = output_scrubber
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_mechanism(entity, 'Program', self.__program)
     super(CliAgent, self).export_to_json_snapshot(snapshot, entity)
 
@@ -221,7 +221,7 @@ class CliRunOperation(base_agent.AgentOperation):
     self.__args = list(args)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_control(entity, 'Args', self.__args)
     super(CliRunOperation, self).export_to_json_snapshot(snapshot, entity)
 
@@ -253,7 +253,7 @@ class CliAgentObservationFailureVerifier(jc.ObservationFailureVerifier):
     self.__error_regex = error_regex
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_control(entity, 'Regex', self.__error_regex)
     super(CliAgentObservationFailureVerifier, self).export_to_json_snapshot(
         snapshot, entity)

--- a/citest/service_testing/http_agent.py
+++ b/citest/service_testing/http_agent.py
@@ -23,7 +23,7 @@ import traceback
 import urllib2
 
 from ..base import JournalLogger
-from ..base import JsonSnapshotable
+from ..base import JsonSnapshotableEntity
 from .http_scrubber import HttpScrubber
 
 from . import base_agent
@@ -32,7 +32,7 @@ from . import base_agent
 class HttpResponseType(
     collections.namedtuple('HttpResponseType',
                            ['http_code', 'output', 'exception']),
-    JsonSnapshotable):
+    JsonSnapshotableEntity):
   """Holds the results from an HTTP message.
 
   Attributes:
@@ -52,7 +52,7 @@ class HttpResponseType(
         self.http_code, self.output, self.exception)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface.
+    """Implements JsonSnapshotableEntity interface.
 
     The payload will be emitted as a string. Consider calling
     export_to_json_snapshot_with_format instead to specify the payload format.
@@ -60,7 +60,7 @@ class HttpResponseType(
     self.export_to_json_snapshot_with_format(snapshot, entity, format=None)
 
   def export_to_json_snapshot_with_format(self, snapshot, entity, format):
-    """Helper function for JsonSnapshotable, allowing a format specification.
+    """Helper function for JsonSnapshotableEntity, allowing a format tag.
 
     Args:
       snapshot: [JsonSnapshot] The snapshot owning the entity.
@@ -260,7 +260,7 @@ class HttpAgent(base_agent.BaseAgent):
     self.add_header('Authorization', 'Basic ' + encoded_auth)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_control(entity, 'Base URL', self.__base_url)
     super(HttpAgent, self).export_to_json_snapshot(snapshot, entity)
 
@@ -450,7 +450,7 @@ class BaseHttpOperation(base_agent.AgentOperation):
     self.__snapshot_format = format
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_control(entity, 'URL Path', self.__path)
     edge = snapshot.edge_builder.make_data(entity, 'Payload Data', self.__data)
     if self.__snapshot_format:

--- a/citest/service_testing/http_observer.py
+++ b/citest/service_testing/http_observer.py
@@ -71,7 +71,7 @@ class HttpObjectObserver(jc.ObjectObserver):
     return 'HttpObjectObserver({0})'.format(self.__agent)
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_mechanism(entity, 'Agent', self.__agent)
     snapshot.edge_builder.make_control(entity, 'Path', self.__path)
     super(HttpObjectObserver, self).export_to_json_snapshot(snapshot, entity)
@@ -198,7 +198,7 @@ class HttpObservationFailureVerifier(jc.ObservationFailureVerifier):
     self.__error_regex = error_regex
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_control(entity, 'HTTP Code', self.__http_code)
     if self.__error_regex:
       snapshot.edge_builder.make_control(entity, 'Regex', self.__error_regex)

--- a/citest/service_testing/operation_contract.py
+++ b/citest/service_testing/operation_contract.py
@@ -15,10 +15,10 @@
 
 """Specifies test cases using BaseAgents."""
 
-from ..base import JsonSnapshotable
+from ..base import JsonSnapshotableEntity
 
 
-class OperationContract(JsonSnapshotable):
+class OperationContract(JsonSnapshotableEntity):
   """Specifies a testable operation and contract to verify it.
 
   This is essentially a "test case" using  BaseAgents.
@@ -58,7 +58,7 @@ class OperationContract(JsonSnapshotable):
     return self.__cleanup
 
   def export_to_json_snapshot(self, snapshot, entity):
-    """Implements JsonSnapshotable interface."""
+    """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make(entity, 'Operation', self.__operation)
     snapshot.edge_builder.make(entity, 'Contract', self.__contract)
 

--- a/tests/base/journal_test.py
+++ b/tests/base/journal_test.py
@@ -26,19 +26,19 @@ import unittest
 from StringIO import StringIO
 from citest.base import Journal
 
-from citest.base import JsonSnapshot, JsonSnapshotable
+from citest.base import JsonSnapshot, JsonSnapshotableEntity
 from citest.base import RecordOutputStream, RecordInputStream
 
 from test_clock import TestClock
 
 
-class TestDetails(JsonSnapshotable):
+class TestDetails(JsonSnapshotableEntity):
   def export_to_json_snapshot(self, snapshot, entity):
     snapshot.edge_builder.make(entity, 'DetailR', 3.14)
     snapshot.edge_builder.make(entity, 'DetailB', True)
 
 
-class TestData(JsonSnapshotable):
+class TestData(JsonSnapshotableEntity):
   def __init__(self, name, param, data=None):
     self.__name = name
     self.__param = param
@@ -49,7 +49,7 @@ class TestData(JsonSnapshotable):
     entity.add_metadata('param', self.__param)
 
     if self.__data:
-      data = snapshot.make_entity_for_data(self.__data)
+      data = snapshot.make_entity_for_object(self.__data)
       snapshot.edge_builder.make(entity, 'Data', data)
     return entity
 
@@ -150,7 +150,7 @@ class JournalTest(unittest.TestCase):
     data = TestData('NAME', 1234, TestDetails())
     decoder = json.JSONDecoder(encoding='ASCII')
     snapshot = JsonSnapshot()
-    snapshot.add_data(data)
+    snapshot.add_object(data)
 
     time_function = lambda: 1.23
     journal = Journal(time_function)
@@ -187,14 +187,14 @@ class JournalTest(unittest.TestCase):
     self.assertEquals(4, len(got))
 
     snapshot = JsonSnapshot()
-    snapshot.add_data(first)
+    snapshot.add_object(first)
     json_object = snapshot.to_json_object()
     json_object['_timestamp'] = journal.clock.last_time - 1
     json_object['_thread'] = threading.current_thread().ident
     self.assertItemsEqual(json_object, got[1])
 
     snapshot = JsonSnapshot()
-    snapshot.add_data(second)
+    snapshot.add_object(second)
     json_object = snapshot.to_json_object()
     json_object['_timestamp'] = journal.clock.last_time
     json_object['_thread'] = threading.current_thread().ident

--- a/tests/json_contract/value_observation_verifier_test.py
+++ b/tests/json_contract/value_observation_verifier_test.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-from citest.base import JsonSnapshotable
+from citest.base import JsonSnapshotableEntity
 from citest.base import JsonSnapshotHelper
 import citest.json_contract as jc
 import citest.json_predicate as jp
@@ -37,7 +37,7 @@ _MULTI_ARRAY = [_LETTER_DICT, _NUMBER_DICT, _LETTER_DICT, _NUMBER_DICT]
 
 class JsonValueObservationVerifierTest(unittest.TestCase):
   def assertEqual(self, expect, have, msg=''):
-    if not isinstance(expect, JsonSnapshotable):
+    if not isinstance(expect, JsonSnapshotableEntity):
       super(JsonValueObservationVerifierTest, self).assertEqual(expect, have, msg)
       return
     try:

--- a/tests/reporting/html_renderer_test.py
+++ b/tests/reporting/html_renderer_test.py
@@ -15,14 +15,14 @@
 """Test citest.reporting.html_renderer module."""
 
 import unittest
-from citest.base import (JsonSnapshotable, JsonSnapshot)
+from citest.base import (JsonSnapshotableEntity, JsonSnapshot)
 from citest.reporting.html_document_manager import HtmlDocumentManager
 from citest.reporting.html_renderer import HtmlRenderer
 from citest.reporting.html_renderer import ProcessToRenderInfo
 from citest.reporting.journal_processor import ProcessedEntityManager
 
 
-class TestLinkedList(JsonSnapshotable):
+class TestLinkedList(JsonSnapshotableEntity):
   # pylint: disable=missing-docstring
   # pylint: disable=too-few-public-methods
   def __init__(self, name, next_elem=None):
@@ -32,7 +32,7 @@ class TestLinkedList(JsonSnapshotable):
   def export_to_json_snapshot(self, snapshot, entity):
     entity.add_metadata('name', self.__name)
     if self.next:
-      next_target = snapshot.make_entity_for_data(self.next)
+      next_target = snapshot.make_entity_for_object(self.next)
       snapshot.edge_builder.make(entity, 'Next', next_target)
 
 
@@ -117,7 +117,7 @@ class HtmlRendererTest(unittest.TestCase):
     tail = TestLinkedList(name='tail')
     head = TestLinkedList(name='head', next_elem=tail)
     snapshot = JsonSnapshot()
-    snapshot.make_entity_for_data(head)
+    snapshot.make_entity_for_object(head)
     json_snapshot = snapshot.to_json_object()
 
     entity_manager = ProcessedEntityManager()
@@ -177,7 +177,7 @@ class HtmlRendererTest(unittest.TestCase):
     processor = ProcessToRenderInfo(
         HtmlDocumentManager('test_json'), entity_manager)
 
-    snapshot.make_entity_for_data(head)
+    snapshot.make_entity_for_object(head)
     json_snapshot = snapshot.to_json_object()
     self.assertEqual(1, json_snapshot.get('_subject_id'))
     entity_manager.push_entity_map(json_snapshot.get('_entities'))


### PR DESCRIPTION
Renamed JsonSnapshotable to JsonSnapshotableEntity meaning that the JSON
representation is an entity (composite value). Added JsonSnapshotable base
class with a method that returns a JSON value that can be added into a snapshot
representation.

The difference is that objects can be made "JsonSnapshotable" that return
simple values rather than composite values. This will allow wrapper objects
(for edge values) that can return simple values without having to expose the
wrapper to the snapshot.

This is also a bit simpler API, even just for JsonSnapshotableEntity.

Also, renamed the snapshot _for_data methods as _for_object because
they refer to "entities" (which are composite objects) and not simple
data objects (e.g. wrapped values). Simple objects arent added to snapshots,
though are used for edge attributes describing relationships between objects
in a snapshot.

@lwander 