### PR TITLE
Added context to predicate evaluation

### DIFF
--- a/citest/aws_testing/aws_contract.py
+++ b/citest/aws_testing/aws_contract.py
@@ -58,7 +58,7 @@ class AwsObjectObserver(jc.ObjectObserver):
 
     if not isinstance(doc, list):
       doc = [doc]
-    self.filter_all_objects_to_observation(doc, observation)
+    self.filter_all_objects_to_observation(context, doc, observation)
 
     return observation.objects
 

--- a/citest/base/execution_context.py
+++ b/citest/base/execution_context.py
@@ -136,5 +136,3 @@ class ExecutionContext(JsonSnapshotable):
       return value(self)
     else:
       return value
-
-      

--- a/citest/gcp_testing/gcp_compute_agent.py
+++ b/citest/gcp_testing/gcp_compute_agent.py
@@ -70,6 +70,6 @@ class GcpComputeAgent(GcpAgent):
           result.extend(data_values)
       return result
 
-    return self.list_resource(context, esource_type,
+    return self.list_resource(context, resource_type,
                               method_variant='aggregatedList',
                               item_list_transform=transform, **kwargs)

--- a/citest/gcp_testing/gcp_contract.py
+++ b/citest/gcp_testing/gcp_contract.py
@@ -52,11 +52,10 @@ class GcpObjectObserver(jc.ObjectObserver):
 
   def collect_observation(self, context, observation, trace=True):
     try:
-      result = self.__method(context, **self.__kwargs)
-      if isinstance(result, list):
-        observation.add_all_objects(result)
-      else:
-        observation.add_object(result)
+      doc = self.__method(context, **self.__kwargs)
+      if not isinstance(doc, list):
+        doc = [doc]
+      self.filter_all_objects_to_observation(context, doc, observation)
     except HttpError as http_error:
       logging.getLogger(__name__).info('%s\n%s\n----------------\n',
                                        http_error, traceback.format_exc())

--- a/citest/gcp_testing/quota_predicate.py
+++ b/citest/gcp_testing/quota_predicate.py
@@ -105,10 +105,11 @@ class QuotaPredicate(ValuePredicate):
   def __repr__(self):
     return 'minimum_metrics: {0!r}'.format(self.__minimum_quota)
 
-  def __call__(self, value):
+  def __call__(self, context, value):
     """Implements ValuePredicate.
 
     Args:
+       context: [ExecutionContext] The execution context to evaluate within.
        values: [array of dict] A list of dictionary resource quota descriptions
           following the format returned described by the "quotas" attribute of
           https://cloud.google.com/compute/docs/reference/latest/projects#resource
@@ -128,7 +129,7 @@ class QuotaPredicate(ValuePredicate):
                             comment='Missing metric value.'))
         continue
       pred = PathPredicate('', pred=NUM_GE(expect), transform=self.__diff)
-      result = pred(found)
+      result = pred(context, found)
       builder.append_result(result)
       if not result:
         bad_metrics.append(metric)

--- a/citest/json_contract/observer.py
+++ b/citest/json_contract/observer.py
@@ -146,10 +146,11 @@ class ObjectObserver(JsonSnapshotableEntity):
     """
     self.__filter = filter
 
-  def filter_all_objects_to_observation(self, objects, observation):
+  def filter_all_objects_to_observation(self, context, objects, observation):
     """Add objects to Observation that comply with the observer's filter.
 
     Args:
+      context: The execution context to filter within.
       objects: The list of objects to add.
         Each element will be filtered independently
       observation: The Observation object to add filtered objects to.
@@ -161,7 +162,7 @@ class ObjectObserver(JsonSnapshotableEntity):
     if not isinstance(objects, list):
       objects = [objects]
     for obj in objects:
-      obj_result = self.__filter(obj)
+      obj_result = self.__filter(context, obj)
       if obj_result:
         observation.add_object(obj)
 

--- a/citest/json_contract/value_observation_verifier.py
+++ b/citest/json_contract/value_observation_verifier.py
@@ -197,10 +197,10 @@ class ValueObservationVerifier(ov.ObservationVerifier):
                                         constraint)
 
       if isinstance(constraint, path_predicate.ProducesPathPredicateResult):
-        constraint_result = constraint(object_list)
+        constraint_result = constraint(context, object_list)
       else:
         constraint_result = (
-            path_predicate.PathPredicate('', constraint)(object_list))
+            path_predicate.PathPredicate('', constraint)(context, object_list))
       if not constraint_result:
         logging.getLogger(__name__).debug('FAILED constraint')
         valid = False

--- a/citest/json_predicate/__init__.py
+++ b/citest/json_predicate/__init__.py
@@ -36,6 +36,7 @@ from .path_value import (
 # to validate a a value. It is used to support the finder
 # module to specify how to determine the values we are trying to find.
 from .predicate import (
+    CloneableWithNewSource,
     CompositePredicateResult,
     CompositePredicateResultBuilder,
     PredicateResult,

--- a/citest/json_predicate/cardinality_predicate.py
+++ b/citest/json_predicate/cardinality_predicate.py
@@ -255,7 +255,7 @@ class CardinalityPredicate(predicate.ValuePredicate,
     return 'Cardinality({0}) {1}..{2}'.format(
         self.__path_pred, self.__min, self.__max)
 
-  def __call__(self, obj):
+  def __call__(self, context, obj):
     """Attempt to match object.
 
     Args:
@@ -264,22 +264,24 @@ class CardinalityPredicate(predicate.ValuePredicate,
     Returns:
       PredicateResponse
     """
-    collected_result = self.__path_pred(obj)
+    collected_result = self.__path_pred(context, obj)
     count = len(collected_result.path_values)
 
+    the_max = context.eval(self.__max)
+    the_min = context.eval(self.__min)
     if not count:
-      if self.__max != 0:
+      if the_max != 0:
         return MissingValueCardinalityResult(
             obj, valid=False,
             cardinality_pred=self, path_pred_result=collected_result)
       else:
         result_type = ConfirmedCardinalityResult
 
-    elif self.__max == 0:
+    elif the_max == 0:
       result_type = UnexpectedValueCardinalityResult
 
-    elif (count >= self.__min
-          and (self.__max is None or count <= self.__max)):
+    elif (count >= the_min
+          and (the_max is None or count <= the_max)):
       result_type = ConfirmedCardinalityResult
 
     else:

--- a/citest/json_predicate/logic_predicate.py
+++ b/citest/json_predicate/logic_predicate.py
@@ -49,11 +49,11 @@ class ConjunctivePredicate(predicate.ValuePredicate):
     snapshot.edge_builder.make(entity, 'Conjunction', self.__conjunction,
                                join='AND')
 
-  def __call__(self, value):
+  def __call__(self, context, value):
     everything = []
     valid = True
     for pred in self.__conjunction:
-      result = pred(value)
+      result = pred(context, value)
       everything.append(result)
       if not result:
         valid = False
@@ -93,11 +93,11 @@ class DisjunctivePredicate(predicate.ValuePredicate):
     snapshot.edge_builder.make(entity, 'Disjunction', self.__disjunction,
                                join='OR')
 
-  def __call__(self, value):
+  def __call__(self, context, value):
     everything = []
     valid = False
     for pred in self.__disjunction:
-      result = pred(value)
+      result = pred(context, value)
       everything.append(result)
       if result:
         valid = True
@@ -132,8 +132,8 @@ class NegationPredicate(predicate.ValuePredicate):
     """Implements JsonSnapshotableEntity interface."""
     snapshot.edge_builder.make_mechanism(entity, 'Predicate', self.__pred)
 
-  def __call__(self, value):
-    base_result = self.__pred(value)
+  def __call__(self, context, value):
+    base_result = self.__pred(context, value)
     return predicate.CompositePredicateResult(
         valid=not base_result.valid, pred=self, results=[base_result])
 
@@ -209,18 +209,18 @@ class ConditionalPredicate(predicate.ValuePredicate):
     if self.__else_pred:
       snapshot.edge_builder.make_mechanism(entity, 'Else', self.__else_pred)
 
-  def __call__(self, value):
+  def __call__(self, context, value):
     if self.__demorgan_pred:
-      return self.__demorgan_pred(value)
+      return self.__demorgan_pred(context, value)
 
     # Run the "if" predicate
     # then, depending on the result, run either "then" or "else" predicate.
-    result = self.__if_pred(value)
+    result = self.__if_pred(context, value)
     tried = [result]
     if result:
-      result = self.__then_pred(value)
+      result = self.__then_pred(context, value)
     else:
-      result = self.__else_pred(value)
+      result = self.__else_pred(context, value)
     tried.append(result)
 
     return predicate.CompositePredicateResult(

--- a/citest/json_predicate/map_predicate.py
+++ b/citest/json_predicate/map_predicate.py
@@ -188,7 +188,7 @@ class MapPredicate(predicate.ValuePredicate):
     return (self.__class__ == pred.__class__
             and self.__pred == pred.pred)
 
-  def __call__(self, obj):
+  def __call__(self, context, obj):
     """Determine if object or its members match the expected fields.
 
     Args:
@@ -208,15 +208,17 @@ class MapPredicate(predicate.ValuePredicate):
 
     if obj_list != None:
       for elem in obj_list:
-        result = self.__pred(elem)
+        result = self.__pred(context, elem)
         all_results.append(result)
         if result:
           good_map.append(ObjectResultMapAttempt(elem, result))
         else:
           bad_map.append(ObjectResultMapAttempt(elem, result))
 
-    valid = not (self.__min != None and len(good_map) < self.__min
-                 or self.__max != None and len(good_map) > self.__max)
+    the_min = context.eval(self.__min)
+    the_max = context.eval(self.__max)
+    valid = not (the_min != None and len(good_map) < the_min
+                 or the_max != None and len(good_map) > the_max)
     return MapPredicateResult(
         valid=valid, pred=self.__pred,
         obj_list=obj_list,

--- a/citest/json_predicate/path_result.py
+++ b/citest/json_predicate/path_result.py
@@ -22,11 +22,11 @@ from .path_value import (
     PathValue)
 
 from .predicate import (
-    CloneableWithContext,
+    CloneableWithNewSource,
     PredicateResult)
 
 
-class PathResult(PredicateResult, CloneableWithContext):
+class PathResult(PredicateResult, CloneableWithNewSource):
   """Common base class for results whose subject is a field within a composite.
 
   Attributes:
@@ -61,8 +61,8 @@ class PathResult(PredicateResult, CloneableWithContext):
     builder.make_output(entity, 'PathValue', self.__path_value)
     super(PathResult, self).export_to_json_snapshot(snapshot, entity)
 
-  def clone_in_context(self, source, base_target_path, base_value_path):
-    """Implements CloneableWithContext interface."""
+  def clone_with_source(self, source, base_target_path, base_value_path):
+    """Implements CloneableWithNewSource interface."""
     target_path = (base_target_path if not self.__target_path
                    else PATH_SEP.join([base_target_path, self.__target_path]))
     value_path = (base_value_path if not self.__path_value.path
@@ -70,9 +70,9 @@ class PathResult(PredicateResult, CloneableWithContext):
                                       self.__path_value.path]))
     path_value = PathValue(value_path, self.__path_value.value)
 
-    return self._do_clone_in_context(source, target_path, path_value)
+    return self._do_clone_with_source(source, target_path, path_value)
 
-  def _do_clone_in_context(self, source, final_path, final_path_value):
+  def _do_clone_with_source(self, source, final_path, final_path_value):
     return self.__class__(
         source=source, target_path=final_path, path_value=final_path_value,
         valid=self.valid, comment=self.comment, cause=self.cause)
@@ -144,7 +144,7 @@ class PathValueResult(PathResult):
     return '{0} pred={1}'.format(super(PathValueResult, self).__repr__(),
                                  self.__pred)
 
-  def _do_clone_in_context(self, source, final_path, final_path_value):
+  def _do_clone_with_source(self, source, final_path, final_path_value):
     """Specializes interface to pass through filter."""
     return self.__class__(
         source=source, target_path=final_path, path_value=final_path_value,
@@ -194,7 +194,7 @@ class TypeMismatchError(PathResult):
     """The value type we found."""
     return self.__got_type
 
-  def _do_clone_in_context(self, source, final_path, final_path_value):
+  def _do_clone_with_source(self, source, final_path, final_path_value):
     """Specializes interface to pass through types."""
 
     return self.__class__(

--- a/citest/json_predicate/path_transforms.py
+++ b/citest/json_predicate/path_transforms.py
@@ -37,9 +37,9 @@ class FieldDifference(JsonSnapshotableEntity):
       minuend: [string] The field of the value to subtract from.
       subtractend: [string] The field of the value to substract.
     """
-    if minuend.find(PATH_SEP) >= 0:
+    if not callable(minuend) and minuend.find(PATH_SEP) >= 0:
       raise ValueError('Nested fields are not yet supported.')
-    if subtractend.find(PATH_SEP) >= 0:
+    if not callable(subtractend) and subtractend.find(PATH_SEP) >= 0:
       raise ValueError('Nested fields are not yet supported.')
 
     self.__minuend = minuend
@@ -59,7 +59,7 @@ class FieldDifference(JsonSnapshotableEntity):
         entity, 'Operation',
         '{0} - {1}'.format(self.__minuend, self.__subtractend))
 
-  def __call__(self, source):
+  def __call__(self, context, source):
     """Operator.
 
     Args:
@@ -67,4 +67,13 @@ class FieldDifference(JsonSnapshotableEntity):
     Returns:
       Value of minuend - subtractend
     """
-    return source[self.__minuend] - source[self.__subtractend]
+    minuend_key = context.eval(self.__minuend)
+    subtractend_key = context.eval(self.__subtractend)
+    if minuend_key.find(PATH_SEP) >= 0:
+      raise ValueError('Nested fields "{0}" are not yet supported.'
+                       .format(minuend_key))
+    if subtractend_key.find(PATH_SEP) >= 0:
+      raise ValueError('Nested fields "{0}" are not yet supported.'
+                       .format(subtractend_key))
+
+    return  source[minuend_key] - source[subtractend_key]

--- a/citest/kube_testing/kube_contract.py
+++ b/citest/kube_testing/kube_contract.py
@@ -60,7 +60,7 @@ class KubeObjectObserver(jc.ObjectObserver):
       doc = decoder.decode(kube_response.output)
       if not isinstance(doc, list):
         doc = [doc]
-      observation.add_all_objects(doc)
+      self.filter_all_objects_to_observation(context, doc, observation)
     except ValueError as vex:
       error = 'Invalid JSON in response: %s' % str(kube_response)
       logging.getLogger(__name__).info('%s\n%s\n----------------\n',

--- a/spinnaker/spinnaker_system/google_kato_test.py
+++ b/spinnaker/spinnaker_system/google_kato_test.py
@@ -557,16 +557,17 @@ class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
     logger = logging.getLogger(__name__)
 
     # Get the list of images available (to the service account we are using).
+    context = citest.base.ExecutionContext()
     gcp_agent = self.gcp_observer
     JournalLogger.begin_context('Collecting expected available images')
     relation_context = 'ERROR'
     try:
       logger.debug('Looking up available images.')
 
-      json_doc = gcp_agent.list_resource('images')
+      json_doc = gcp_agent.list_resource(context, 'images')
       for project in GCP_STANDARD_IMAGES.keys():
         logger.info('Looking for images from project=%s', project)
-        found = gcp_agent.list_resource('images', project=project)
+        found = gcp_agent.list_resource(context, 'images', project=project)
         for image in found:
           if not image.get('deprecated', None):
             json_doc.append(image)

--- a/tests/json_contract/observation_verifier_test.py
+++ b/tests/json_contract/observation_verifier_test.py
@@ -57,6 +57,7 @@ class ObservationVerifierTest(unittest.TestCase):
     JsonSnapshotHelper.AssertExpectedValue(expect, have, msg)
 
   def test_result_builder_add_good_result(self):
+    context = ExecutionContext()
     observation = jc.Observation()
     observation.add_object('A')
 
@@ -64,7 +65,7 @@ class ObservationVerifierTest(unittest.TestCase):
     builder = jc.ObservationVerifyResultBuilder(observation)
 
     map_pred = jp.MapPredicate(pred)
-    map_result = map_pred(observation.objects)
+    map_result = map_pred(context, observation.objects)
     builder.add_map_result(map_result)
     verify_results = builder.build(True)
 
@@ -77,6 +78,7 @@ class ObservationVerifierTest(unittest.TestCase):
 
 
   def test_result_builder_add_bad_result(self):
+    context = ExecutionContext()
     observation = jc.Observation()
     observation.add_object('A')
 
@@ -84,7 +86,7 @@ class ObservationVerifierTest(unittest.TestCase):
     builder = jc.ObservationVerifyResultBuilder(observation)
 
     map_pred = jp.MapPredicate(pred)
-    map_result = map_pred(observation.objects)
+    map_result = map_pred(context, observation.objects)
     builder.add_map_result(map_result)
     verify_results = builder.build(False)
 
@@ -96,6 +98,7 @@ class ObservationVerifierTest(unittest.TestCase):
                      verify_results.bad_results)
 
   def test_result_builder_add_mixed_results(self):
+    context = ExecutionContext()
     observation = jc.Observation()
     observation.add_object('GOOD')
     observation.add_object('BAD')
@@ -104,7 +107,7 @@ class ObservationVerifierTest(unittest.TestCase):
     builder = jc.ObservationVerifyResultBuilder(observation)
 
     map_pred = jp.MapPredicate(pred)
-    map_result = map_pred(observation.objects)
+    map_result = map_pred(context, observation.objects)
     builder.add_map_result(map_result)
     verify_results = builder.build(False)
 

--- a/tests/json_contract/observer_test.py
+++ b/tests/json_contract/observer_test.py
@@ -78,7 +78,8 @@ class JsonObserverTest(unittest.TestCase):
     observation = jc.Observation()
     expected = jc.Observation()
     expected.add_object(_NUMBER_DICT)
-    observer.filter_all_objects_to_observation([_NUMBER_DICT], observation)
+    observer.filter_all_objects_to_observation(
+        context, [_NUMBER_DICT], observation)
     self.assertEqual([_NUMBER_DICT], observation.objects)
     self.assertEqual(expected, observation)
 
@@ -89,7 +90,8 @@ class JsonObserverTest(unittest.TestCase):
 
     expected = jc.Observation()
     expected.add_object(_LETTER_DICT)
-    observer.filter_all_objects_to_observation([_LETTER_DICT], observation)
+    observer.filter_all_objects_to_observation(
+        context, [_LETTER_DICT], observation)
     self.assertEqual([_LETTER_DICT], observation.objects)
     self.assertEqual(expected, observation)
 
@@ -98,12 +100,13 @@ class JsonObserverTest(unittest.TestCase):
     expected.add_object(_LETTER_DICT)
     expected.add_object(_LETTER_DICT)
     observer.filter_all_objects_to_observation(
-        [_LETTER_DICT, _NUMBER_DICT, _LETTER_DICT], observation)
+        context, [_LETTER_DICT, _NUMBER_DICT, _LETTER_DICT], observation)
     self.assertEqual([_LETTER_DICT, _LETTER_DICT], observation.objects)
 
     observation = jc.Observation()
     expected = jc.Observation()
-    observer.filter_all_objects_to_observation([_NUMBER_DICT], observation)
+    observer.filter_all_objects_to_observation(
+        context, [_NUMBER_DICT], observation)
     self.assertEqual([], observation.objects)
     # Note that filtering doesnt observe errors.
     self.assertEqual(expected, observation)

--- a/tests/json_contract/value_observation_verifier_test.py
+++ b/tests/json_contract/value_observation_verifier_test.py
@@ -92,7 +92,7 @@ class JsonValueObservationVerifierTest(unittest.TestCase):
         observation.add_object(obj)
 
       for pred in pred_list:
-        builder.add_path_predicate_result(pred(observation.objects))
+        builder.add_path_predicate_result(pred(context, observation.objects))
 
       # All of these tests succeed.
       verify_results = builder.build(True)
@@ -128,7 +128,7 @@ class JsonValueObservationVerifierTest(unittest.TestCase):
         observation.add_object(obj)
 
       for pred in pred_list:
-        builder.add_path_predicate_result(pred(observation.objects))
+        builder.add_path_predicate_result(pred(context, observation.objects))
 
       # None of these tests succeed.
       verify_results = builder.build(False)
@@ -165,7 +165,7 @@ class JsonValueObservationVerifierTest(unittest.TestCase):
         observation.add_object(obj)
 
       for pred in pred_list:
-        builder.add_path_predicate_result(pred(observation.objects))
+        builder.add_path_predicate_result(pred(context, observation.objects))
 
       # None of these tests succeed.
       verify_results = builder.build(False)
@@ -201,8 +201,8 @@ class JsonValueObservationVerifierTest(unittest.TestCase):
         observation.add_object(obj)
 
       for pred in pred_list:
-        pred_result = jp.PathPredicate('', pred)(observation.objects)
-        builder.add_path_predicate_result(pred(observation.objects))
+        pred_result = jp.PathPredicate('', pred)(context, observation.objects)
+        builder.add_path_predicate_result(pred(context, observation.objects))
 
       # None of these tests succeed.
       verify_results = builder.build(False)
@@ -255,7 +255,8 @@ class JsonValueObservationVerifierTest(unittest.TestCase):
       observation.add_all_objects(obj_list)
 
       for pred in pred_list:
-        result_builder.add_path_predicate_result(pred(observation.objects))
+        result_builder.add_path_predicate_result(
+            pred(context, observation.objects))
 
       # All of these tests succeed.
       verify_results = result_builder.build(expect_valid)

--- a/tests/json_predicate/binary_predicate_test.py
+++ b/tests/json_predicate/binary_predicate_test.py
@@ -19,7 +19,9 @@
 
 import unittest
 
-from citest.base import JsonSnapshotHelper
+from citest.base import (
+    ExecutionContext,
+    JsonSnapshotHelper)
 from citest.json_predicate import PathValue
 import citest.json_predicate as jp
 
@@ -61,36 +63,62 @@ class JsonBinaryPredicateTest(unittest.TestCase):
                      got_result)
 
   def test_string_eq(self):
+    context = ExecutionContext()
     eq_abc = jp.STR_EQ('abc')
-    self.assertGoodResult(PathValue('', 'abc'), eq_abc, eq_abc('abc'))
-    self.assertBadResult(PathValue('', 'abcd'), eq_abc, eq_abc('abcd'))
+    self.assertGoodResult(PathValue('', 'abc'), eq_abc, eq_abc(context, 'abc'))
+    self.assertBadResult(PathValue('', 'abcd'), eq_abc, eq_abc(context, 'abcd'))
 
   def test_string_ne(self):
+    context = ExecutionContext()
     ne_abc = jp.STR_NE('abc')
-    self.assertGoodResult(PathValue('', 'abcd'), ne_abc, ne_abc('abcd'))
-    self.assertBadResult(PathValue('', 'abc'), ne_abc, ne_abc('abc'))
+    self.assertGoodResult(PathValue('', 'abcd'),
+                          ne_abc, ne_abc(context, 'abcd'))
+    self.assertBadResult(PathValue('', 'abc'),
+                         ne_abc, ne_abc(context, 'abc'))
 
-  def test_factory_type_mismatch(self):
+  def test_indirect_string(self):
+    context = ExecutionContext(TEST='abc')
+    eq_abc = jp.STR_EQ(lambda x: x['TEST'])
+    self.assertGoodResult(PathValue('', 'abc'), eq_abc, eq_abc(context, 'abc'))
+    self.assertBadResult(PathValue('', 'abcd'), eq_abc, eq_abc(context, 'abcd'))
+
+  def test_factory_type_ok(self):
+    context = ExecutionContext()
     factory = jp.StandardBinaryPredicateFactory(
         '==', lambda a, b: True, operand_type=basestring)
-    try:
-      self.assertFalse(factory(['not a string']), "Expected type error")
-    except TypeError:
-      pass
 
     pred = factory('is a string')
-    self.assertTrue(pred('ok'))
+    self.assertTrue(pred(context, 'ok'))
+
+    pred = factory(lambda x: 'is a string')
+    self.assertTrue(pred(context, 'ok'))
+
+  def test_factory_type_mismatch(self):
+    context = ExecutionContext()
+    factory = jp.StandardBinaryPredicateFactory(
+        '==', lambda a, b: True, operand_type=basestring)
+    self.assertRaises(TypeError, factory, ['not a string'])
+
+    pred = factory(lambda x: ['not a string'])
+    self.assertRaises(TypeError, pred, context, 'ok')
 
   def test_string_substr(self):
+    context = ExecutionContext()
     substr_q = jp.STR_SUBSTR('q')
     substr_pqr = jp.STR_SUBSTR('pqr')
-    self.assertGoodResult(PathValue('', 'pqr'), substr_q, substr_q('pqr'))
-    self.assertGoodResult(PathValue('', 'rqp'), substr_q, substr_q('rqp'))
-    self.assertGoodResult(PathValue('', 'pqr'), substr_pqr, substr_pqr('pqr'))
-    self.assertBadResult(PathValue('', 'abc'), substr_q, substr_q('abc'))
-    self.assertBadResult(PathValue('', 'xyz'), substr_q, substr_q('xyz'))
+    self.assertGoodResult(PathValue('', 'pqr'),
+                          substr_q, substr_q(context, 'pqr'))
+    self.assertGoodResult(PathValue('', 'rqp'),
+                          substr_q, substr_q(context, 'rqp'))
+    self.assertGoodResult(PathValue('', 'pqr'),
+                          substr_pqr, substr_pqr(context, 'pqr'))
+    self.assertBadResult(PathValue('', 'abc'),
+                         substr_q, substr_q(context, 'abc'))
+    self.assertBadResult(PathValue('', 'xyz'),
+                         substr_q, substr_q(context, 'xyz'))
 
-  def standard_operand_type_mismatch_helper(self, expected_type, factory,
+  def standard_operand_type_mismatch_helper(self,
+                                            context, expected_type, factory,
                                             good_operand, bad_operand):
     """Helper method used to generate operand type mismatch errors.
 
@@ -99,80 +127,99 @@ class JsonBinaryPredicateTest(unittest.TestCase):
       good_operand: A good operand value.
       bad_operand: A bad operand value.
     """
-    try:
-      self.assertFalse(factory(bad_operand), "Expected type error.")
-    except TypeError:
-      pass
+    self.assertRaises(TypeError, factory, bad_operand)
 
     pred = factory(good_operand)
     try:
       self.assertEqual(
           jp.TypeMismatchError(
               expected_type, bad_operand.__class__, bad_operand),
-          pred(bad_operand))
+          pred(context, bad_operand))
     except:
       print '\nFAILED value={0} pred={1}'.format(good_operand, pred.name)
       raise
 
   def test_standard_string_operator_type_mismatch(self):
+    context = ExecutionContext()
     for value in [['value'], {'a':'A'}, 1]:
       for factory in [jp.STR_EQ, jp.STR_NE]:
         self.standard_operand_type_mismatch_helper(
-            basestring, factory, good_operand='test value', bad_operand=value)
+            context, basestring, factory,
+            good_operand='test value', bad_operand=value)
 
   def test_string_specific_operator_type_mismatch(self):
+    context = ExecutionContext()
     operand = 'valid string operand.'
     for value in [['value'], {'a':'A'}, 1]:
       for factory in [jp.STR_SUBSTR]:
         self.standard_operand_type_mismatch_helper(
-            basestring, factory, operand, value)
+            context, basestring, factory, operand, value)
 
   def test_dict_eq(self):
+    context = ExecutionContext()
     letters = {'a':'A', 'b':'B', 'c':'C'}
     operand = {'a': 'A', 'b': 'B'}
     eq_pred = jp.DICT_EQ(operand)
 
     self.assertBadResult(PathValue('', letters),
-                         eq_pred, eq_pred(letters))
+                         eq_pred, eq_pred(context, letters))
     self.assertGoodResult(PathValue('', operand),
-                          eq_pred, eq_pred(operand))
+                          eq_pred, eq_pred(context, operand))
     self.assertBadResult(PathValue('', {'a': 'A'}),
-                         eq_pred, eq_pred({'a': 'A'}))
+                         eq_pred, eq_pred(context, {'a': 'A'}))
+
+  def test_dict_eq_indirect(self):
+    context = ExecutionContext(testA='A', testKey='b')
+    letters = {'a':'A', 'b':'B', 'c':'C'}
+    operand = {'a': lambda x: x['testA'], 'b': 'B'}
+    actual_operand = {'a': 'A', 'b': 'B'}
+    eq_pred = jp.DICT_EQ(operand)
+
+    self.assertBadResult(PathValue('', letters),
+                         eq_pred, eq_pred(context, letters))
+    self.assertGoodResult(PathValue('', actual_operand),
+                          eq_pred, eq_pred(context, actual_operand))
+    self.assertBadResult(PathValue('', {'a': 'A'}),
+                         eq_pred, eq_pred(context, {'a': 'A'}))
 
   def test_dict_ne(self):
+    context = ExecutionContext()
     letters = {'a':'A', 'b':'B', 'c':'C'}
     operand = {'a': 'A', 'b': 'B'}
     ne_pred = jp.DICT_NE(operand)
 
     self.assertGoodResult(PathValue('', letters),
-                          ne_pred, ne_pred(letters))
-    self.assertBadResult(PathValue('', operand), ne_pred, ne_pred(operand))
+                          ne_pred, ne_pred(context, letters))
+    self.assertBadResult(PathValue('', operand),
+                         ne_pred, ne_pred(context, operand))
     self.assertGoodResult(PathValue('', {'a': 'A'}),
-                          ne_pred, ne_pred({'a': 'A'}))
+                          ne_pred, ne_pred(context, {'a': 'A'}))
 
   def test_dict_simple_subset(self):
+    context = ExecutionContext()
     letters = {'a':'A', 'b':'B', 'c':'C'}
     operand = {'a': 'A', 'b': 'B'}
     subset_pred = jp.DICT_SUBSET(operand)
 
     self.assertGoodResult(PathValue('', letters),
-                          subset_pred, subset_pred(letters))
+                          subset_pred, subset_pred(context, letters))
     self.assertGoodResult(PathValue('', operand),
-                          subset_pred, subset_pred(operand))
+                          subset_pred, subset_pred(context, operand))
     source = {'a':'A'}
     self.assertEqual(
         jp.MissingPathError(source=source, target_path='b',
                             path_value=PathValue('', source)),
-        subset_pred(source))
+        subset_pred(context, source))
 
   def test_dict_nested_subset(self):
+    context = ExecutionContext()
     small = {'first':'Apple', 'second':'Banana'}
     small_subset_pred = jp.DICT_SUBSET(small)
 
     big = {'first':'Apple', 'second':'Banana', 'third':'Cherry'}
 
     self.assertGoodResult(
-        PathValue('', big), small_subset_pred, small_subset_pred(big))
+        PathValue('', big), small_subset_pred, small_subset_pred(context, big))
 
     small_nested = {'outer':small}
     small_nested_subset_pred = jp.DICT_SUBSET(small_nested)
@@ -180,9 +227,10 @@ class JsonBinaryPredicateTest(unittest.TestCase):
     big_nested = {'outer':big, 'another':big}
     self.assertGoodResult(PathValue('', big_nested),
                           small_nested_subset_pred,
-                          small_nested_subset_pred(big_nested))
+                          small_nested_subset_pred(context, big_nested))
 
   def test_dict_nested_subset_exact_keys(self):
+    context = ExecutionContext()
     small_dict = {'first':'Apple', 'second':'Banana'}
     small_nested_dict = {'outer':small_dict}
 
@@ -192,7 +240,7 @@ class JsonBinaryPredicateTest(unittest.TestCase):
     self.assertEqual(
         jp.MissingPathError(source=small_nested_dict, target_path='out',
                             path_value=PathValue('', small_nested_dict)),
-        subset_pred(small_nested_dict))
+        subset_pred(context, small_nested_dict))
 
     # In dictionary we want exact key matches, not subkeys.
     nested_operand = {'fir':'Apple'}
@@ -202,9 +250,10 @@ class JsonBinaryPredicateTest(unittest.TestCase):
         jp.MissingPathError(source=small_nested_dict,
                             target_path=jp.PATH_SEP.join(['outer', 'fir']),
                             path_value=PathValue('outer', small_dict)),
-        subset_pred(small_nested_dict))
+        subset_pred(context, small_nested_dict))
 
   def test_dict_nested_subset_exact_values(self):
+    context = ExecutionContext()
     small = {'first':'Apple', 'second':'Banana'}
     small_nested = {'outer':small}
 
@@ -219,9 +268,10 @@ class JsonBinaryPredicateTest(unittest.TestCase):
             path_value=PathValue(jp.PATH_SEP.join(['outer', 'first']), 'Apple'),
             source=small_nested,
             target_path=jp.PATH_SEP.join(['outer', 'first'])),
-        subset_pred(small_nested))
+        subset_pred(context, small_nested))
 
   def test_dict_subset_with_array_values(self):
+    context = ExecutionContext()
     small = {'a':['A'], 'b':[1, 2]}
     big = {'a':['A', 'B', 'C'], 'b':[1, 2, 3], 'c':['red', 'yellow']}
     small_nested = {'first':small}
@@ -233,27 +283,30 @@ class JsonBinaryPredicateTest(unittest.TestCase):
     # These are matching the outer source objects because they contain
     # the subset we are looking for.
     self.assertGoodResult(
-        PathValue('', big), small_subset_pred, small_subset_pred(big))
+        PathValue('', big), small_subset_pred, small_subset_pred(context, big))
     self.assertGoodResult(
         PathValue('', big_nested), nested_subset_pred,
-        nested_subset_pred(big_nested))
+        nested_subset_pred(context, big_nested))
 
   def test_standard_dict_operator_type_mismatch(self):
+    context = ExecutionContext()
     operand = {'a': 'A'}
     for value in [['a'], 'a', 1]:
       for factory in [jp.DICT_EQ, jp.DICT_NE]:
         self.standard_operand_type_mismatch_helper(
-            dict, factory, good_operand=operand, bad_operand=value)
+            context, dict, factory, good_operand=operand, bad_operand=value)
 
   def test_dict_specific_operator_type_mismatch(self):
+    context = ExecutionContext()
     operand = {'a': 'A'}
     for value in [['a'], 'a', 1]:
       for factory in [jp.DICT_SUBSET]:
         self.standard_operand_type_mismatch_helper(
-            dict, factory, operand, value)
+            context, dict, factory, operand, value)
 
   def test_dict_subset_with_array_nodes(self):
     # See test_collect_with_dict_subset for comparison.
+    context = ExecutionContext()
     letters = {'a':'A', 'b':'B', 'c':'C'}
     numbers = {'a':1, 'b':2}
     both = [letters, numbers]
@@ -266,24 +319,25 @@ class JsonBinaryPredicateTest(unittest.TestCase):
     self.assertEqual(
         jp.MissingPathError(source=source, target_path='a',
                             path_value=PathValue('', source)),
-        letter_subset_pred(source))
+        letter_subset_pred(context, source))
 
   def test_collect_with_dict_subset(self):
     # See test_dict_subset_with_array_nodes for comparision.
+    context = ExecutionContext()
     letters = {'a':'A', 'b':'B', 'c':'C'}
     numbers = {'a':1, 'b':2}
     both = [letters, numbers]
     source = {'items': both}
     letter_subset_pred = jp.DICT_SUBSET({'a':'A'})
     path_pred = jp.PathPredicate('items', pred=letter_subset_pred)
-    result = path_pred(source)
+    result = path_pred(context, source)
 
     mismatch_error = jp.TypeMismatchError(
         expect_type=(int, long, float), got_type=str,
         source=source,
         target_path=jp.PATH_SEP.join(['items', 'a']),
         path_value=PathValue('items[1]', numbers))
-    valid_result = letter_subset_pred(letters).clone_in_context(
+    valid_result = letter_subset_pred(context, letters).clone_with_source(
         source=source, base_target_path='items', base_value_path='items[0]')
     self.assertEqual(
         # pylint: disable=bad-continuation
@@ -295,6 +349,7 @@ class JsonBinaryPredicateTest(unittest.TestCase):
         result)
 
   def test_list_subset_nonstrict_good(self):
+    context = ExecutionContext()
     letters = {'a':'A', 'b':'B', 'c':'C'}
     numbers = {'a':1, 'b':2, 'c':'C'}
     source = [letters, numbers]
@@ -303,9 +358,10 @@ class JsonBinaryPredicateTest(unittest.TestCase):
     self.assertFalse(common_subset_pred.strict)
     self.assertGoodResult(
         PathValue('', source), common_subset_pred,
-        common_subset_pred(source))
+        common_subset_pred(context, source))
 
   def test_list_subset_nonstrict_bad(self):
+    context = ExecutionContext()
     letters = {'a':'A', 'b':'B', 'c':'C'}
     numbers = {'a':1, 'b':2, 'c':'C'}
     source = [letters, numbers]
@@ -317,9 +373,10 @@ class JsonBinaryPredicateTest(unittest.TestCase):
             valid=False, pred=common_subset_pred,
             source=source, target_path='',
             path_value=PathValue('', source)),
-        common_subset_pred(source))
+        common_subset_pred(context, source))
 
   def test_list_subset_strict_good(self):
+    context = ExecutionContext()
     letters = {'a':'A', 'b':'B', 'c':'C'}
     numbers = {'a':1, 'b':2, 'c':'C'}
     source = [letters, numbers]
@@ -327,9 +384,10 @@ class JsonBinaryPredicateTest(unittest.TestCase):
     common_subset_pred = jp.LIST_SUBSET([letters], strict=True)
     self.assertGoodResult(
         PathValue('', source), common_subset_pred,
-        common_subset_pred(source))
+        common_subset_pred(context, source))
 
   def test_list_subset_strict_bad(self):
+    context = ExecutionContext()
     letters = {'a':'A', 'b':'B', 'c':'C'}
     numbers = {'a':1, 'b':2, 'c':'C'}
     source = [letters, numbers]
@@ -337,16 +395,30 @@ class JsonBinaryPredicateTest(unittest.TestCase):
     common_subset_pred = jp.LIST_SUBSET([{'c':'C'}], strict=True)
     self.assertBadResult(
         PathValue('', source), common_subset_pred,
-        common_subset_pred(source))
+        common_subset_pred(context, source))
 
   def test_list_equivalent(self):
+    context = ExecutionContext()
     source = [{'a':'A', 'b':'B'}, {'one':1, 'two':2}]
     pred = jp.EQUIVALENT([source[1], source[0]])
-    result = pred(source)
+    result = pred(context, source)
     self.assertEqual(
         jp.PathValueResult(valid=True, source=source, target_path='',
                            path_value=PathValue('', source),
                            pred=jp.LIST_SIMILAR(pred.operand)),
+        result)
+
+  def test_list_equivalent_indirect(self):
+    context = ExecutionContext(testB='B', second={'one':1, 'two':2})
+    source = [{'a':'A', 'b': lambda x: x['testB']}, lambda x: x['second']]
+    actual_source = [{'a':'A', 'b':'B'}, {'one':1, 'two':2}]
+
+    pred = jp.EQUIVALENT(source)
+    result = pred(context, actual_source)
+    self.assertEqual(
+        jp.PathValueResult(valid=True, source=actual_source, target_path='',
+                           path_value=PathValue('', actual_source),
+                           pred=jp.LIST_SIMILAR(actual_source)),
         result)
 
 

--- a/tests/json_predicate/cardinality_predicate_test.py
+++ b/tests/json_predicate/cardinality_predicate_test.py
@@ -18,7 +18,9 @@
 
 import unittest
 
-from citest.base import JsonSnapshotHelper
+from citest.base import (
+    ExecutionContext,
+    JsonSnapshotHelper)
 from citest.json_predicate import PathValue
 import citest.json_predicate as jp
 
@@ -41,6 +43,7 @@ class CardinalityPredicateTest(unittest.TestCase):
       raise
 
   def test_cardinality_bounds_1(self):
+    context = ExecutionContext()
     for min in range(0, 3):
       for max in range(0, 3):
         if min > max:
@@ -50,7 +53,7 @@ class CardinalityPredicateTest(unittest.TestCase):
         expect_ok = min <= 1 and max >= 1
 
         source = _CAB
-        result = predicate(source)
+        result = predicate(context, source)
 
         all_results = [
             jp.CompositePredicateResult(
@@ -92,17 +95,20 @@ class CardinalityPredicateTest(unittest.TestCase):
                   predicate, expect_path_result),
               result)
 
-  def test_cardinality_bounds_2(self):
+  def test_cardinality_bounds_2_indirect(self):
+    predicate = jp.CardinalityPredicate(_AorB,
+                                        min=lambda x: x['min'],
+                                        max=lambda x: x['max'])
     for min in range(0, 3):
       for max in range(0, 3):
         if min > max:
           continue
 
-        predicate = jp.CardinalityPredicate(_AorB, min=min, max=max)
+        context = ExecutionContext(min=min, max=max)
         expect_ok = min <= 2 and max >= 2
 
         source = _CAB
-        result = predicate(source)
+        result = predicate(context, source)
 
         all_results = [
             jp.CompositePredicateResult(

--- a/tests/json_predicate/logic_predicate_test.py
+++ b/tests/json_predicate/logic_predicate_test.py
@@ -17,7 +17,9 @@
 
 import unittest
 
-from citest.base import JsonSnapshotHelper
+from citest.base import (
+    ExecutionContext,
+    JsonSnapshotHelper)
 import citest.json_predicate as jc
 import citest.json_predicate.path_predicate_helpers as jp
 
@@ -30,61 +32,66 @@ class LogicPredicateTest(unittest.TestCase):
     JsonSnapshotHelper.AssertExpectedValue(expect, have, msg)
 
   def test_conjunction_true(self):
+    context = ExecutionContext()
     aA = jp.PathEqPredicate('a', 'A')
     bB = jp.PathEqPredicate('b', 'B')
     conjunction = jc.AND([aA, bB])
     expect = jc.CompositePredicateResult(
         valid=True, pred=conjunction,
-        results=[aA(_LETTER_DICT), bB(_LETTER_DICT)])
+        results=[aA(context, _LETTER_DICT), bB(context, _LETTER_DICT)])
 
-    result = conjunction(_LETTER_DICT)
+    result = conjunction(context, _LETTER_DICT)
     self.assertTrue(result)
     self.assertEqual(expect, result)
 
   def test_conjunction_false_aborts_early(self):
+    context = ExecutionContext()
     aA = jp.PathEqPredicate('a', 'A')
     b2 = jp.PathEqPredicate('b', 2)
     bB = jp.PathEqPredicate('b', 'B')
     conjunction = jc.AND([aA, b2, bB])
     expect = jc.CompositePredicateResult(
         valid=False, pred=conjunction,
-        results=[aA(_LETTER_DICT), b2(_LETTER_DICT)])
+        results=[aA(context, _LETTER_DICT), b2(context, _LETTER_DICT)])
 
-    result = conjunction(_LETTER_DICT)
+    result = conjunction(context, _LETTER_DICT)
     self.assertFalse(result)
     self.assertEqual(expect, result)
 
   def test_disjunction_true_aborts_early(self):
+    context = ExecutionContext()
     aA = jp.PathEqPredicate('a', 'A')
     bB = jp.PathEqPredicate('b', 'B')
     disjunction = jc.OR([aA, bB])
     expect = jc.CompositePredicateResult(
         valid=True, pred=disjunction,
-        results=[aA(_LETTER_DICT)])
+        results=[aA(context, _LETTER_DICT)])
 
-    result = disjunction(_LETTER_DICT)
+    result = disjunction(context, _LETTER_DICT)
     self.assertTrue(result)
     self.assertEqual(expect, result)
 
   def test_disjunction_false(self):
+    context = ExecutionContext()
     a1 = jp.PathEqPredicate('a', 1)
     b2 = jp.PathEqPredicate('b', 2)
     disjunction = jc.OR([a1, b2])
     expect = jc.CompositePredicateResult(
         valid=False, pred=disjunction,
-        results=[a1(_LETTER_DICT), b2(_LETTER_DICT)])
+        results=[a1(context, _LETTER_DICT), b2(context, _LETTER_DICT)])
 
-    result = disjunction(_LETTER_DICT)
+    result = disjunction(context, _LETTER_DICT)
     self.assertFalse(result)
     self.assertEqual(expect, result)
 
   def test_not_success(self):
+    context = ExecutionContext()
     a1 = jp.PathEqPredicate('a', '1')
     not_a1 = jc.NOT(a1)
 
     expect = jc.CompositePredicateResult(
-        valid=True, pred=not_a1, results=[a1(_LETTER_DICT)])
-    result = not_a1(_LETTER_DICT)
+        valid=True, pred=not_a1, results=[a1(context, _LETTER_DICT)])
+    result = not_a1(context, _LETTER_DICT)
     self.assertTrue(result)
     self.assertEqual(expect, result)
 
@@ -92,18 +99,20 @@ class LogicPredicateTest(unittest.TestCase):
     b2_or_a1 = jc.OR([b2, a1])
     not_b2_or_a1 = jc.NOT(b2_or_a1)
     expect = jc.CompositePredicateResult(
-        valid=True, pred=not_b2_or_a1, results=[b2_or_a1(_LETTER_DICT)])
-    result = not_b2_or_a1(_LETTER_DICT)
+        valid=True, pred=not_b2_or_a1,
+        results=[b2_or_a1(context, _LETTER_DICT)])
+    result = not_b2_or_a1(context, _LETTER_DICT)
     self.assertTrue(result)
     self.assertEqual(expect, result)
 
   def test_not_fail(self):
+    context = ExecutionContext()
     aA = jp.PathEqPredicate('a', 'A')
     not_aA = jc.NOT(aA)
 
     expect = jc.CompositePredicateResult(
-        valid=False, pred=not_aA, results=[aA(_LETTER_DICT)])
-    result = not_aA(_LETTER_DICT)
+        valid=False, pred=not_aA, results=[aA(context, _LETTER_DICT)])
+    result = not_aA(context, _LETTER_DICT)
     self.assertFalse(result)
     self.assertEqual(expect, result)
 
@@ -111,12 +120,14 @@ class LogicPredicateTest(unittest.TestCase):
     bB_or_aA = jc.OR([bB, aA])
     not_bB_or_aA = jc.NOT(bB_or_aA)
     expect = jc.CompositePredicateResult(
-        valid=False, pred=not_bB_or_aA, results=[bB_or_aA(_LETTER_DICT)])
-    result = not_bB_or_aA(_LETTER_DICT)
+        valid=False, pred=not_bB_or_aA,
+        results=[bB_or_aA(context, _LETTER_DICT)])
+    result = not_bB_or_aA(context, _LETTER_DICT)
     self.assertFalse(result)
     self.assertEqual(expect, result)
 
   def test_condition_success(self):
+    context = ExecutionContext()
     aA = jp.PathEqPredicate('a', 'A')
     bB = jp.PathEqPredicate('b', 'B')
     ifAthenB = jc.IF(aA, bB)
@@ -124,28 +135,43 @@ class LogicPredicateTest(unittest.TestCase):
 
     test_cases = [_LETTER_DICT, {'a':'X', 'b':'Y'}, {'a':'X', 'b':'B'}]
     for test in test_cases:
-      expect = demorgan(test)
-      result = ifAthenB(test)
+      expect = demorgan(context, test)
+      result = ifAthenB(context, test)
+      self.assertTrue(result)
+      self.assertEqual(expect, result)
+
+  def test_condition_indirect_success(self):
+    context = ExecutionContext(a='A', b='B')
+    aA = jp.PathEqPredicate('a', lambda x: x['a'])
+    bB = jp.PathEqPredicate('b', lambda x: x['b'])
+    ifAthenB = jc.IF(aA, bB)
+    demorgan = jc.OR([jc.NOT(aA), bB])
+
+    test_cases = [_LETTER_DICT, {'a':'X', 'b':'Y'}, {'a':'X', 'b':'B'}]
+    for test in test_cases:
+      expect = demorgan(context, test)
+      result = ifAthenB(context, test)
       self.assertTrue(result)
       self.assertEqual(expect, result)
 
   def test_condition_fail(self):
+    context = ExecutionContext()
     aA = jp.PathEqPredicate('a', 'A')
     b2 = jp.PathEqPredicate('b', '2')
     ifAthen2 = jc.IF(aA, b2)
     demorgan = jc.OR([jc.NOT(aA), b2])
 
-    expect = demorgan(_LETTER_DICT)
-    result = ifAthen2(_LETTER_DICT)
+    expect = demorgan(context, _LETTER_DICT)
+    result = ifAthen2(context, _LETTER_DICT)
     self.assertFalse(result)
     self.assertEqual(expect, result)
 
   def test_condition_else_success(self):
-    aA = jp.PathEqPredicate('a', 'A')
-    bB = jp.PathEqPredicate('b', 'B')
-    cC = jp.PathEqPredicate('c', 'C')
+    context = ExecutionContext(a='A', b='B', c='C')
+    aA = jp.PathEqPredicate('a', lambda x: x['a'])
+    bB = jp.PathEqPredicate('b', lambda x: x['b'])
+    cC = jp.PathEqPredicate('c', lambda x: x['c'])
 
-    aA_and_bB = jc.AND([aA, bB])
     ifAthenBelseC = jc.IF(aA, bB, cC)
 
     # True if all conditions are true.
@@ -154,25 +180,27 @@ class LogicPredicateTest(unittest.TestCase):
     test_cases = [_LETTER_DICT,
                   {'a':'A', 'b':'B', 'c':'X'},
                   {'a':'X', 'b':'B', 'c':'C'},
-                  {'a':'X', 'b':'X', 'c':'C'}]
+                  {'a':'X', 'b':'X', 'c':'C'},
+                 ]
 
     for i in range(3):
       test = test_cases[i]
-      tried = [aA(test)]
+      tried = [aA(context, test)]
       if i < 2:
         # First two have true IF to just execute THEN
-        tried.append(bB(test))
+        tried.append(bB(context, test))
       else:
         # Remainder have false IF to just execute ELSE
-        tried.append(cC(test))
+        tried.append(cC(context, test))
 
       expect = jc.CompositePredicateResult(
           valid=True, pred=ifAthenBelseC, results=tried)
-      result = ifAthenBelseC(test)
+      result = ifAthenBelseC(context, test)
       self.assertTrue(result)
       self.assertEqual(expect, result)
 
   def test_condition_else_fail(self):
+    context = ExecutionContext()
     aA = jp.PathEqPredicate('a', 'A')
     bB = jp.PathEqPredicate('b', 'B')
     cC = jp.PathEqPredicate('c', 'C')
@@ -185,17 +213,17 @@ class LogicPredicateTest(unittest.TestCase):
                   {'a':'X', 'b':'B', 'c':'D'}]
     for i in range(2):
       test = test_cases[i]
-      tried = [aA(test)]
+      tried = [aA(context, test)]
       if i < 1:
         # First has true IF so tries THEN
-        tried.append(bB(test))
+        tried.append(bB(context, test))
       else:
         # Remainder has false IF so tries ELSE
-        tried.append(cC(test))
+        tried.append(cC(context, test))
 
       expect = jc.CompositePredicateResult(
           valid=False, pred=ifAthenBelseC, results=tried)
-      result = ifAthenBelseC(test)
+      result = ifAthenBelseC(context, test)
       self.assertFalse(result)
       self.assertEqual(expect, result)
 

--- a/tests/json_predicate/map_predicate_test.py
+++ b/tests/json_predicate/map_predicate_test.py
@@ -19,11 +19,11 @@
 
 import unittest
 
-from citest.base import JsonSnapshotHelper
-import citest.json_predicate as jp
+from citest.base import (
+    ExecutionContext,
+    JsonSnapshotHelper)
 from citest.json_predicate.path_predicate_helpers import PathEqPredicate
-import citest.json_predicate as lp
-import citest.json_predicate as mp
+import citest.json_predicate as jp
 
 
 _LETTER_DICT = {'a':'A', 'b':'B', 'z':'Z'}
@@ -41,7 +41,7 @@ class JsonMapPredicateTest(unittest.TestCase):
   def assertEqual(self, expect, have, msg=''):
     JsonSnapshotHelper.AssertExpectedValue(expect, have, msg)
 
-  def _try_map(self, pred, obj, expect_ok, expect_map_result=None,
+  def _try_map(self, context, pred, obj, expect_ok, expect_map_result=None,
                dump=False, min=1):
     """Helper function for invoking finder and asserting the result.
 
@@ -50,10 +50,10 @@ class JsonMapPredicateTest(unittest.TestCase):
       obj: The object to apply the predicate to.
       expect_ok: Whether we expect apply to succeed or not.
       expect_map_result: If not None, then the expected
-          mp.MapPredicateResult from apply().
+          jp.MapPredicateResult from apply().
       dump: If True then print the filter_result to facilitate debugging.
     """
-    map_result = mp.MapPredicate(pred, min=min)(obj)
+    map_result = jp.MapPredicate(pred, min=min)(context, obj)
     if dump:
       print 'MAP_RESULT:\n{0}\n'.format(
           JsonSnapshotHelper.ValueToEncodedJson(map_result))
@@ -66,96 +66,126 @@ class JsonMapPredicateTest(unittest.TestCase):
     self.assertEqual(expect_ok, map_result.__nonzero__(), error_msg)
 
   def test_map_predicate_good_1(self):
+    context = ExecutionContext()
     aA = jp.PathPredicate('a', jp.STR_EQ('A'))
 
-    aA_attempt = mp.ObjectResultMapAttempt(_LETTER_DICT, aA(_LETTER_DICT))
-    expect_result = mp.MapPredicateResult(
+    aA_attempt = jp.ObjectResultMapAttempt(_LETTER_DICT,
+                                           aA(context, _LETTER_DICT))
+    expect_result = jp.MapPredicateResult(
         valid=True, pred=aA,
         obj_list=[_LETTER_DICT], all_results=[aA_attempt.result],
         good_map=[aA_attempt],
         bad_map=[])
 
-    self._try_map(aA, _LETTER_DICT, True, expect_result)
+    self._try_map(context, aA, _LETTER_DICT, True, expect_result)
 
   def test_map_predicate_bad(self):
+    context = ExecutionContext()
     aA = jp.PathPredicate('a', jp.STR_EQ('A'))
 
-    expect_result = mp.MapPredicateResult(
+    expect_result = jp.MapPredicateResult(
         valid=False, pred=aA,
-        obj_list=[_NUMBER_DICT], all_results=[aA(_NUMBER_DICT)],
-        bad_map=[mp.ObjectResultMapAttempt(_NUMBER_DICT, aA(_NUMBER_DICT))],
+        obj_list=[_NUMBER_DICT], all_results=[aA(context, _NUMBER_DICT)],
+        bad_map=[jp.ObjectResultMapAttempt(_NUMBER_DICT,
+                                           aA(context, _NUMBER_DICT))],
         good_map=[])
 
-    self._try_map(aA, _NUMBER_DICT, False, expect_result)
+    self._try_map(context, aA, _NUMBER_DICT, False, expect_result)
 
   def test_map_predicate_good_and_bad_min_1(self):
+    context = ExecutionContext()
     aA = jp.PathPredicate('a', jp.STR_EQ('A'))
 
-    aa_number_attempt = mp.ObjectResultMapAttempt(_NUMBER_DICT,
-                                                  aA(_NUMBER_DICT))
-    aa_letter_attempt = mp.ObjectResultMapAttempt(_LETTER_DICT,
-                                                  aA(_LETTER_DICT))
-    expect_result = mp.MapPredicateResult(
+    aa_number_attempt = jp.ObjectResultMapAttempt(_NUMBER_DICT,
+                                                  aA(context, _NUMBER_DICT))
+    aa_letter_attempt = jp.ObjectResultMapAttempt(_LETTER_DICT,
+                                                  aA(context, _LETTER_DICT))
+    expect_result = jp.MapPredicateResult(
         valid=True, pred=aA,
         obj_list=[_NUMBER_DICT, _LETTER_DICT],
         all_results=[aa_number_attempt.result, aa_letter_attempt.result],
         good_map=[aa_letter_attempt],
         bad_map=[aa_number_attempt])
 
-    self._try_map(aA, [_NUMBER_DICT, _LETTER_DICT], True, expect_result)
+    self._try_map(context, aA, [_NUMBER_DICT, _LETTER_DICT],
+                  True, expect_result)
 
   def test_map_predicate_good_and_bad_min_2(self):
+    context = ExecutionContext()
     aA = jp.PathPredicate('a', jp.STR_EQ('A'))
 
-    expect_result = mp.MapPredicateResult(
+    expect_result = jp.MapPredicateResult(
         valid=False, pred=aA,
         obj_list=[_NUMBER_DICT, _LETTER_DICT],
-        all_results=[aA(_NUMBER_DICT), aA(_LETTER_DICT)],
-        good_map=[mp.ObjectResultMapAttempt(_LETTER_DICT, aA(_LETTER_DICT))],
-        bad_map=[mp.ObjectResultMapAttempt(_NUMBER_DICT, aA(_NUMBER_DICT))])
+        all_results=[aA(context, _NUMBER_DICT), aA(context, _LETTER_DICT)],
+        good_map=[jp.ObjectResultMapAttempt(_LETTER_DICT,
+                                            aA(context, _LETTER_DICT))],
+        bad_map=[jp.ObjectResultMapAttempt(_NUMBER_DICT,
+                                           aA(context, _NUMBER_DICT))])
 
     self._try_map(
-        aA, [_NUMBER_DICT, _LETTER_DICT], False, expect_result, min=2)
+        context, aA, [_NUMBER_DICT, _LETTER_DICT], False, expect_result, min=2)
 
-  def test_map_not_found(self):
+  def test_map_predicate_good_and_bad_min_indirect(self):
+    context = ExecutionContext(min=2)
     aA = jp.PathPredicate('a', jp.STR_EQ('A'))
 
-    aa_composite_attempt = mp.ObjectResultMapAttempt(_COMPOSITE_DICT,
-                                                     aA(_COMPOSITE_DICT))
-    expect_result = mp.MapPredicateResult(
+    expect_result = jp.MapPredicateResult(
+        valid=False, pred=aA,
+        obj_list=[_NUMBER_DICT, _LETTER_DICT],
+        all_results=[aA(context, _NUMBER_DICT), aA(context, _LETTER_DICT)],
+        good_map=[jp.ObjectResultMapAttempt(_LETTER_DICT,
+                                            aA(context, _LETTER_DICT))],
+        bad_map=[jp.ObjectResultMapAttempt(_NUMBER_DICT,
+                                           aA(context, _NUMBER_DICT))])
+
+    self._try_map(
+        context, aA, [_NUMBER_DICT, _LETTER_DICT], False, expect_result,
+        min=lambda x: x['min'])
+
+  def test_map_not_found(self):
+    context = ExecutionContext()
+    aA = jp.PathPredicate('a', jp.STR_EQ('A'))
+
+    aa_composite_attempt = jp.ObjectResultMapAttempt(
+        _COMPOSITE_DICT, aA(context, _COMPOSITE_DICT))
+    expect_result = jp.MapPredicateResult(
         valid=False, pred=aA,
         obj_list=[_COMPOSITE_DICT], all_results=[aa_composite_attempt.result],
         bad_map=[aa_composite_attempt],
         good_map=[])
 
-    self._try_map(aA, _COMPOSITE_DICT, False, expect_result)
+    self._try_map(context, aA, _COMPOSITE_DICT, False, expect_result)
 
   def test_object_filter_cases(self):
+    context = ExecutionContext()
     aA = jp.PathPredicate('a', jp.STR_EQ('A'))
 
-    self._try_map(aA, _LETTER_DICT, True)
-    self._try_map(aA, _COMPOSITE_DICT, False)
-    self._try_map(aA, _NUMBER_DICT, False)
-    self._try_map(aA, _MULTI_ARRAY, True)
-    self._try_map(aA, [_COMPOSITE_DICT, _COMPOSITE_DICT], False)
-    self._try_map(aA, _MIXED_DICT, True)
+    self._try_map(context, aA, _LETTER_DICT, True)
+    self._try_map(context, aA, _COMPOSITE_DICT, False)
+    self._try_map(context, aA, _NUMBER_DICT, False)
+    self._try_map(context, aA, _MULTI_ARRAY, True)
+    self._try_map(context, aA, [_COMPOSITE_DICT, _COMPOSITE_DICT], False)
+    self._try_map(context, aA, _MIXED_DICT, True)
 
-    AandB = lp.AND([PathEqPredicate('a', 'A'),
+    AandB = jp.AND([PathEqPredicate('a', 'A'),
                     PathEqPredicate('b', 'B')])
-    self._try_map(AandB, _LETTER_DICT, True)
-    self._try_map(AandB, _COMPOSITE_DICT, False)
-    self._try_map(AandB, _NUMBER_DICT, False)
-    self._try_map(AandB, _MULTI_ARRAY, True)
-    self._try_map(AandB, _MIXED_DICT, False)
+    self._try_map(context, AandB, _LETTER_DICT, True)
+    self._try_map(context, AandB, _COMPOSITE_DICT, False)
+    self._try_map(context, AandB, _NUMBER_DICT, False)
+    self._try_map(context, AandB, _MULTI_ARRAY, True)
+    self._try_map(context, AandB, _MIXED_DICT, False)
 
 
   def test_none_bad(self):
+    context = ExecutionContext()
     aA = jp.PathPredicate('a', jp.STR_EQ('A'))
-    self._try_map(aA, None, False)
+    self._try_map(context, aA, None, False)
 
   def test_none_good(self):
+    context = ExecutionContext()
     aA = jp.PathPredicate('a', jp.STR_EQ('A'))
-    self._try_map(aA, None, True, min=0)
+    self._try_map(context, aA, None, True, min=0)
 
 
 if __name__ == '__main__':

--- a/tests/json_predicate/path_predicate_helpers_test.py
+++ b/tests/json_predicate/path_predicate_helpers_test.py
@@ -17,8 +17,12 @@
 
 import unittest
 
-from citest.base import JsonSnapshotHelper
-from citest.json_predicate import PATH_SEP, PathValue
+from citest.base import (
+    ExecutionContext,
+    JsonSnapshotHelper)
+from citest.json_predicate import (
+    PATH_SEP,
+    PathValue)
 import citest.json_predicate as jp
 
 
@@ -53,9 +57,10 @@ class JsonPathPredicateTest(unittest.TestCase):
       raise
 
   def test_path_value_found_top(self):
+    context = ExecutionContext()
     source = _COMPOSITE_DICT
     pred = jp.PathEqPredicate('letters', _LETTER_DICT)
-    result = pred(source)
+    result = pred(context, source)
     expect = _make_result(pred, jp.DICT_EQ(_LETTER_DICT), source,
                           [PathValue('letters', _LETTER_DICT)],
                           [])
@@ -63,6 +68,7 @@ class JsonPathPredicateTest(unittest.TestCase):
     self.assertEqual(expect, result)
 
   def test_path_found_in_array(self):
+    context = ExecutionContext()
     pred = jp.PathPredicate(PATH_SEP.join(['outer', 'inner', 'a']))
     simple = {'a': 'A', 'b': 'B'}
     source = {'outer': [{'middle': simple}, {'inner': simple}]}
@@ -73,12 +79,13 @@ class JsonPathPredicateTest(unittest.TestCase):
             path_value=PathValue('outer[0]', source['outer'][0]))]
 
     expect = _make_result(pred, None, source, found, [], pruned)
-    self.assertEqual(expect, pred(source))
+    self.assertEqual(expect, pred(context, source))
 
   def test_path_found_multiple(self):
+    context = ExecutionContext()
     source = {'outer': [_LETTER_DICT, _NUMBER_DICT]}
     pred = jp.PathPredicate(PATH_SEP.join(['outer', 'a']))
-    result = pred(source)
+    result = pred(context, source)
     self.assertEqual(
         _make_result(
             pred, None, source,
@@ -88,9 +95,10 @@ class JsonPathPredicateTest(unittest.TestCase):
         result)
 
   def test_path_value_found_nested(self):
+    context = ExecutionContext()
     source = _COMPOSITE_DICT
     pred = jp.PathEqPredicate(PATH_SEP.join(['letters', 'a']), 'A')
-    result = pred(source)
+    result = pred(context, source)
 
     self.assertEqual(
         _make_result(
@@ -100,9 +108,10 @@ class JsonPathPredicateTest(unittest.TestCase):
     self.assertTrue(result)
 
   def test_path_value_not_found(self):
+    context = ExecutionContext()
     source = _COMPOSITE_DICT
     pred = jp.PathEqPredicate(PATH_SEP.join(['letters', 'a']), 'B')
-    result = pred(source)
+    result = pred(context, source)
     self.assertEqual(
         _make_result(
             pred, jp.STR_EQ('B'), source, [],

--- a/tests/json_predicate/path_predicate_result_test.py
+++ b/tests/json_predicate/path_predicate_result_test.py
@@ -20,6 +20,7 @@
 
 import unittest
 
+from citest.base import ExecutionContext
 from citest.json_predicate import (
     PathPredicate,
     PathPredicateResult,
@@ -50,9 +51,10 @@ class JsonPathPredicateResultTest(unittest.TestCase):
     self.assertEqual(pred_a, pred_b)
 
   def test_path_predicate_result_eq(self):
+    context = ExecutionContext()
     source = {}
     path_pred = PathPredicate('x')
-    a_result = path_pred(source)  # dont care, just something well formed.
+    a_result = path_pred(context, source)  # this is just something well formed.
 
     result_a = PathPredicateResult(
         True, path_pred, source,

--- a/tests/json_predicate/path_transforms_test.py
+++ b/tests/json_predicate/path_transforms_test.py
@@ -20,6 +20,7 @@
 
 import unittest
 
+from citest.base import ExecutionContext
 from citest.json_predicate import FieldDifference
 
 
@@ -37,9 +38,16 @@ class PathTransformTest(unittest.TestCase):
     self.assertNotEqual(orig, diff)
 
   def test_field_difference(self):
+    context = ExecutionContext()
     source = {'a': 7, 'b': 4}
     xform = FieldDifference('a', 'b')
-    self.assertEqual(3, xform(source))
+    self.assertEqual(3, xform(context, source))
+
+  def test_field_difference_indirect(self):
+    context = ExecutionContext()
+    source = {'a': 7, 'b': 4}
+    xform = FieldDifference(lambda x: 'b', lambda x: 'a')
+    self.assertEqual(-3, xform(context, source))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Renamed CloneableInContext to CloneableWithNewSource to avoid
overloading the term "context". The context in journals and evaluation
are still overloaded but expect them to become explicitly related in
the future.

@lwander this is the last of the CLs for now. This completes the feature for runtime value injection from an execution context.