### PR TITLE
Replace RC with RS in kube_smoke_test

### DIFF
--- a/spinnaker/spinnaker_system/kube_smoke_test.py
+++ b/spinnaker/spinnaker_system/kube_smoke_test.py
@@ -268,9 +268,9 @@ class KubeSmokeTestScenario(sk.SpinnakerTestScenario):
         application=self.TEST_APP)
 
     builder = kube.KubeContractBuilder(self.kube_observer)
-    (builder.new_clause_builder('Replication Controller Added',
+    (builder.new_clause_builder('Replica Set Added',
                                 retryable_for_secs=15)
-     .get_resources('rc', extra_args=[group_name])
+     .get_resources('rs', extra_args=[group_name])
      .contains_path_eq('spec/replicas', 1))
 
     return st.OperationContract(
@@ -414,8 +414,8 @@ class KubeSmokeTestScenario(sk.SpinnakerTestScenario):
         description='Destroy Server Group: ' + group_name)
 
     builder = kube.KubeContractBuilder(self.kube_observer)
-    (builder.new_clause_builder('Replication Controller Removed')
-     .get_resources('rc', extra_args=[group_name],
+    (builder.new_clause_builder('Replica Set Removed')
+     .get_resources('rs', extra_args=[group_name],
                     no_resource_ok=True)
      .contains_path_eq('targetSize', 0))
 
@@ -437,9 +437,9 @@ class KubeSmokeTestScenario(sk.SpinnakerTestScenario):
         user='[anonymous]')
 
     builder = kube.KubeContractBuilder(self.kube_observer)
-    (builder.new_clause_builder('Replication Controller Added',
+    (builder.new_clause_builder('Replica Set Added',
                                 retryable_for_secs=15)
-     .get_resources('rc', extra_args=[group_name])
+     .get_resources('rs', extra_args=[group_name])
      .contains_path_eq(
          'spec/template/spec/containers/image', 
          self.__desired_image_id))


### PR DESCRIPTION
Replication controllers have been replaced with replica sets for the Kubernetes provider. This caused the tests to fail.

@ewiseblatt 