### PR TITLE
Give more time to kato deregister test

### DIFF
--- a/spinnaker/spinnaker_system/google_kato_test.py
+++ b/spinnaker/spinnaker_system/google_kato_test.py
@@ -533,7 +533,7 @@ class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
     # error is usually helpful for development.
     builder = gcp.GcpContractBuilder(self.gcp_observer)
     (builder.new_clause_builder('Instances not in Target Pool',
-                                retryable_for_secs=5)
+                                retryable_for_secs=30)
        .list_resource(
           'targetPools', region=self.bindings['TEST_GCE_REGION'])
        .excludes_pred_list(


### PR DESCRIPTION
@jtk54 
TBR
I dont think this is it because the test passes for me in < 2 secs over all so there was plenty of time before. But this will help rule out time being a factor in the failures we've been seeing.

Also slow down the poll rate for short observations.