### PR TITLE
Changed operation status_collector and cleanup functions.

### DIFF
--- a/citest/base/execution_context.py
+++ b/citest/base/execution_context.py
@@ -47,6 +47,9 @@ class ExecutionContext(JsonSnapshotable):
     elif key in self.__external:
       del self.__external[key]
 
+  def __setitem__(self, key, value):
+    self.set_snapshotable(key, value)
+
   def __getitem__(self, key):
     return (self.__internal[key]
             if key in self.__internal

--- a/spinnaker/spinnaker_system/bake_and_deploy_test.py
+++ b/spinnaker/spinnaker_system/bake_and_deploy_test.py
@@ -528,7 +528,13 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
   def new_jenkins_build_operation(self):
     return None
 
-  def delete_baked_image(self, status, unused_verify_results):
+  def delete_baked_image(self, execution_context):
+    status = execution_context.get('OperationStatus', None)
+    if status is None:
+      self.log.info(
+          'Operation could not be performed so there is no image to delete.')
+      return;
+
     status = status.trigger_status
     detail = status.detail_doc
     if isinstance(detail, list):


### PR DESCRIPTION
@jtk54 
The old status_collector (and cleanup) functions predated contexts.
Changed status_collector to status_extractor, whose responsibility can
be to move values from the status into the context. in the case of spinnaker,
this could traverse the complex json data to extract out a couple individual
fields that might be referenced by a test.

Cleanup just takes a context. The run_test_case method adds the verify results
into the context so they are still available (and the status was already there).

I also renamed the keys that the run_test_case writes into the context to be
camel case to match the type names. I dont think anything was referencing this
yet.