### PR TITLE
Breaking change to spinnaker.binding key names.

### DIFF
--- a/citest/service_testing/base_agent.py
+++ b/citest/service_testing/base_agent.py
@@ -276,7 +276,7 @@ class AgentOperationStatus(JsonSnapshotableEntity):
           else:
             logger.debug(
                 'Still waiting (approx %d left). Check in %r secs',
-                sleep_secs, secs_remaining)
+                secs_remaining, sleep_secs)
           # Hardcoded once-a-minute confirmation that we're still waiting.
           next_log_secs = now + 60
 

--- a/spinnaker/spinnaker_system/aws_kato_test.py
+++ b/spinnaker/spinnaker_system/aws_kato_test.py
@@ -129,7 +129,7 @@ class AwsKatoTestScenario(sk.SpinnakerTestScenario):
     payload = self.agent.type_to_payload(
         'upsertAmazonLoadBalancerDescription',
         {
-            'credentials': bindings['AWS_CREDENTIALS'],
+            'credentials': bindings['SPINNAKER_AWS_ACCOUNT'],
             'clusterName': bindings['TEST_APP'],
             'name': detail_raw_name,
             'availabilityZones': {region: avail_zones},
@@ -179,7 +179,7 @@ class AwsKatoTestScenario(sk.SpinnakerTestScenario):
     payload = self.agent.type_to_payload(
         'deleteAmazonLoadBalancerDescription',
         {
-            'credentials': self.bindings['AWS_CREDENTIALS'],
+            'credentials': self.bindings['SPINNAKER_AWS_ACCOUNT'],
             'regions': [region],
             'loadBalancerName': self.__use_lb_name
         })

--- a/spinnaker/spinnaker_system/aws_smoke_test.py
+++ b/spinnaker/spinnaker_system/aws_smoke_test.py
@@ -196,7 +196,7 @@ class AwsSmokeTestScenario(sk.SpinnakerTestScenario):
             # 'loadBalancerName': load_balancer_name,
 
 
-            'credentials': bindings['AWS_CREDENTIALS'],
+            'credentials': bindings['SPINNAKER_AWS_ACCOUNT'],
             'name': load_balancer_name,
             'stack': bindings['TEST_STACK'],
             'detail': self.lb_detail,
@@ -276,13 +276,13 @@ class AwsSmokeTestScenario(sk.SpinnakerTestScenario):
             'type': 'deleteLoadBalancer',
             'cloudProvider': 'aws',
 
-            'credentials': self.bindings['AWS_CREDENTIALS'],
+            'credentials': self.bindings['SPINNAKER_AWS_ACCOUNT'],
             'regions': [self.bindings['TEST_AWS_REGION']],
             'loadBalancerName': load_balancer_name
         }],
         description='Delete Load Balancer: {0} in {1}:{2}'.format(
             load_balancer_name,
-            self.bindings['AWS_CREDENTIALS'],
+            self.bindings['SPINNAKER_AWS_ACCOUNT'],
             self.bindings['TEST_AWS_REGION']),
         application=self.TEST_APP)
 
@@ -324,7 +324,7 @@ class AwsSmokeTestScenario(sk.SpinnakerTestScenario):
             'type': 'createServerGroup',
             'cloudProvider': 'aws',
             'application': self.TEST_APP,
-            'credentials': bindings['AWS_CREDENTIALS'],
+            'credentials': bindings['SPINNAKER_AWS_ACCOUNT'],
             'strategy':'',
             'capacity': {'min':2, 'max':2, 'desired':2},
             'targetHealthyDeployPercentage': 100,
@@ -338,7 +338,7 @@ class AwsSmokeTestScenario(sk.SpinnakerTestScenario):
             'terminationPolicies': ['Default'],
 
             'availabilityZones': {region: avail_zones},
-            'keyPair': bindings['AWS_CREDENTIALS'] + '-keypair',
+            'keyPair': bindings['SPINNAKER_AWS_ACCOUNT'] + '-keypair',
             'suspendedProcesses': [],
             # TODO(ewiseblatt): Inquiring about how this value is determined.
             # It seems to be the "Name" tag value of one of the VPCs
@@ -354,7 +354,7 @@ class AwsSmokeTestScenario(sk.SpinnakerTestScenario):
             'amiName': bindings['TEST_AWS_AMI'],
             'instanceType': 'm1.small',
             'useSourceCapacity': False,
-            'account': bindings['AWS_CREDENTIALS'],
+            'account': bindings['SPINNAKER_AWS_ACCOUNT'],
             'user': '[anonymous]'
         }],
         description='Create Server Group in ' + group_name,
@@ -391,7 +391,7 @@ class AwsSmokeTestScenario(sk.SpinnakerTestScenario):
             'asgName': group_name,
             'region': bindings['TEST_AWS_REGION'],
             'regions': [bindings['TEST_AWS_REGION']],
-            'credentials': bindings['AWS_CREDENTIALS'],
+            'credentials': bindings['SPINNAKER_AWS_ACCOUNT'],
             'user': '[anonymous]'
         }],
         application=self.TEST_APP,

--- a/spinnaker/spinnaker_system/bake_and_deploy_test.py
+++ b/spinnaker/spinnaker_system/bake_and_deploy_test.py
@@ -220,7 +220,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
           'provider': 'gce',
           'stack': bindings['TEST_STACK'],
           'detail': self.__short_lb_name,
-          'credentials': bindings['GCE_CREDENTIALS'],
+          'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
           'region': bindings['TEST_GCE_REGION'],
           'ipProtocol': 'TCP',
           'portRange': spec['port'],
@@ -267,12 +267,12 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
           'loadBalancerName': self.__full_lb_name,
           'region': bindings['TEST_GCE_REGION'],
           'regions': [bindings['TEST_GCE_REGION']],
-          'credentials': bindings['GCE_CREDENTIALS'],
+          'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
           'user': '[anonymous]'
        }],
        description='Delete Load Balancer: {0} in {1}:{2}'.format(
           self.__full_lb_name,
-          bindings['GCE_CREDENTIALS'],
+          bindings['SPINNAKER_GOOGLE_ACCOUNT'],
           bindings['TEST_GCE_REGION']),
       application=self.TEST_APP)
 
@@ -347,7 +347,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
         'instanceType': 'f1-micro',
         'image': None,
         'targetSize': 1,
-        'account': self.bindings['GCE_CREDENTIALS']
+        'account': self.bindings['SPINNAKER_GOOGLE_ACCOUNT']
       }]
     }
 
@@ -356,7 +356,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
     result = {
       'cloudProvider': cloudProvider,
       'cloudProviderType': cloudProvider,
-      'credentials': self.bindings['GCE_CREDENTIALS'],
+      'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
       'name': 'Destroy Server Group',
       'refId': 'DESTROY',
       'requisiteStageRefIds': requisiteStages or [],
@@ -380,7 +380,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
       'target': 'current_asg_dynamic',
       'cluster': '{app}-{stack}'.format(
           app=self.TEST_APP, stack=self.bindings['TEST_STACK']),
-      'credentials': self.bindings['GCE_CREDENTIALS']
+      'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT']
     }
     result.update(kwargs)
     return result

--- a/spinnaker/spinnaker_system/google_http_lb_upsert_scenario.py
+++ b/spinnaker/spinnaker_system/google_http_lb_upsert_scenario.py
@@ -91,7 +91,7 @@ class GoogleHttpLoadBalancerTestScenario(sk.SpinnakerTestScenario):
       'cloudProvider': 'gce',
       'provider': 'gce',
       'stack': bindings['TEST_STACK'],
-      'credentials': bindings['GCE_CREDENTIALS'],
+      'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
       'region': bindings['TEST_GCE_REGION'],
       'loadBalancerType': 'HTTP',
       'loadBalancerName': self.__lb_name,
@@ -319,7 +319,7 @@ class GoogleHttpLoadBalancerTestScenario(sk.SpinnakerTestScenario):
       'loadBalancerName': self.__lb_name,
       'region': bindings['TEST_GCE_REGION'],
       'regions': [bindings['TEST_GCE_REGION']],
-      'credentials': bindings['GCE_CREDENTIALS'],
+      'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
       'user': '[anonymous]'
     }
 
@@ -327,7 +327,7 @@ class GoogleHttpLoadBalancerTestScenario(sk.SpinnakerTestScenario):
       job=[delete],
       description='Delete L7 Load Balancer: {0} in {1}:{2}'.format(
         self.__lb_name,
-        bindings['GCE_CREDENTIALS'],
+        bindings['SPINNAKER_GOOGLE_ACCOUNT'],
         bindings['TEST_GCE_REGION'],
       ),
       application=self.TEST_APP
@@ -524,7 +524,7 @@ class GoogleHttpLoadBalancerTestScenario(sk.SpinnakerTestScenario):
           'backingData': {'networks': ['default']},
           'cloudProvider': 'gce',
           'application': self.TEST_APP,
-          'credentials': bindings['GCE_CREDENTIALS'],
+          'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
           'description': '',
           'detail': 'http',
           'ipIngress': [
@@ -591,7 +591,7 @@ class GoogleHttpLoadBalancerTestScenario(sk.SpinnakerTestScenario):
       job=[{
         'cloudProvider': 'gce',
         'application': self.TEST_APP,
-        'credentials': bindings['GCE_CREDENTIALS'],
+        'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
         'strategy':'',
         'capacity': {'min':1, 'max':1, 'desired':1},
         'targetSize': 1,
@@ -620,7 +620,7 @@ class GoogleHttpLoadBalancerTestScenario(sk.SpinnakerTestScenario):
           'backend-service-names': 'backend-service',
           'load-balancing-policy': json.dumps(policy)
         },
-        'account': bindings['GCE_CREDENTIALS'],
+        'account': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
         'authScopes': ['compute'],
         'user': '[anonymous]'
       }],
@@ -662,7 +662,7 @@ class GoogleHttpLoadBalancerTestScenario(sk.SpinnakerTestScenario):
         'type': 'destroyServerGroup',
         'regions': [bindings['TEST_GCE_REGION']],
         'zones': [bindings['TEST_GCE_ZONE']],
-        'credentials': bindings['GCE_CREDENTIALS'],
+        'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
         'user': '[anonymous]'
       }],
       application=self.TEST_APP,

--- a/spinnaker/spinnaker_system/google_kato_test.py
+++ b/spinnaker/spinnaker_system/google_kato_test.py
@@ -163,7 +163,7 @@ class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
             'image': image_name[i],
             'instanceType': machine_type[i],
             'zone': self.use_instance_zones[i],
-            'credentials': self.bindings['GCE_CREDENTIALS']
+            'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT']
             }
         })
 
@@ -232,7 +232,7 @@ class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
           {
             'instanceIds': names,
             'zone': zone,
-            'credentials': self.bindings['GCE_CREDENTIALS']
+            'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT']
           })
 
     return st.OperationContract(
@@ -246,7 +246,7 @@ class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
     payload = self.agent.type_to_payload(
         'upsertGoogleServerGroupTagsDescription',
         {
-          'credentials': self.bindings['GCE_CREDENTIALS'],
+          'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
           'zone': self.bindings['TEST_GCE_ZONE'],
           'serverGroupName': 'katotest-server-group',
           'tags': ['test-tag-1', 'test-tag-2']
@@ -315,7 +315,7 @@ class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
           'healthCheck': health_check,
           'portRange': port_range,
           'loadBalancerName': logical_http_lb_name,
-          'credentials': self.bindings['GCE_CREDENTIALS']
+          'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT']
         })
 
     builder = gcp.GcpContractBuilder(self.gcp_observer)
@@ -359,7 +359,7 @@ class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
         'deleteGoogleHttpLoadBalancerDescription',
         {
           'loadBalancerName': self.__use_http_lb_name,
-          'credentials': self.bindings['GCE_CREDENTIALS']
+          'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT']
         })
 
     builder = gcp.GcpContractBuilder(self.gcp_observer)
@@ -412,7 +412,7 @@ class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
         {
           'healthCheck': health_check,
           'region': self.bindings['TEST_GCE_REGION'],
-          'credentials': self.bindings['GCE_CREDENTIALS'],
+          'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
           'loadBalancerName': self.__use_lb_name
         })
 
@@ -445,7 +445,7 @@ class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
         'deleteGoogleLoadBalancerDescription',
         {
           'region': self.bindings['TEST_GCE_REGION'],
-          'credentials': self.bindings['GCE_CREDENTIALS'],
+          'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
           'loadBalancerName': self.__use_lb_name
         })
 
@@ -484,7 +484,7 @@ class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
           'loadBalancerNames': [self.__use_lb_name],
           'instanceIds': self.use_instance_names[:2],
           'region': self.bindings['TEST_GCE_REGION'],
-          'credentials': self.bindings['GCE_CREDENTIALS']
+          'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT']
         })
 
     builder = gcp.GcpContractBuilder(self.gcp_observer)
@@ -522,7 +522,7 @@ class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
           'loadBalancerNames': [self.__use_lb_name],
           'instanceIds': self.use_instance_names[:2],
           'region': self.bindings['TEST_GCE_REGION'],
-          'credentials': self.bindings['GCE_CREDENTIALS']
+          'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT']
         })
 
     # NOTE(ewiseblatt): 20150530

--- a/spinnaker/spinnaker_system/google_server_group_test.py
+++ b/spinnaker/spinnaker_system/google_server_group_test.py
@@ -75,7 +75,7 @@ class GoogleServerGroupTestScenario(sk.SpinnakerTestScenario):
       'provider': 'gce',
       'stack': self.TEST_STACK,
       'detail': 'frontend',
-      'credentials': self.bindings['GCE_CREDENTIALS'],
+      'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
       'region': self.TEST_REGION,
       'listeners': [{
         'protocol': 'TCP',
@@ -106,7 +106,7 @@ class GoogleServerGroupTestScenario(sk.SpinnakerTestScenario):
     job = [{
       'application': self.TEST_APP,
       'stack': self.TEST_STACK,
-      'credentials': self.bindings['GCE_CREDENTIALS'],
+      'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
       'zone': self.TEST_ZONE,
       'network': 'default',
       'targetSize': 1,
@@ -127,7 +127,7 @@ class GoogleServerGroupTestScenario(sk.SpinnakerTestScenario):
       'instanceType': 'f1-micro',
       'initialNumReplicas': 1,
       'type': 'createServerGroup',
-      'account': self.bindings['GCE_CREDENTIALS'],
+      'account': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
       'user': 'integration-tests'
     }]
 
@@ -163,7 +163,7 @@ class GoogleServerGroupTestScenario(sk.SpinnakerTestScenario):
       'type': 'resizeServerGroup',
       'regions': [self.TEST_REGION],
       'zones': [self.TEST_ZONE],
-      'credentials': self.bindings['GCE_CREDENTIALS'],
+      'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
       'cloudProvider': 'gce',
       'user': 'integration-tests'
     }]
@@ -188,7 +188,7 @@ class GoogleServerGroupTestScenario(sk.SpinnakerTestScenario):
     job = [{
       'application': self.TEST_APP,
       'stack': self.TEST_STACK,
-      'credentials': self.bindings['GCE_CREDENTIALS'],
+      'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
       'loadBalancers': [self.__lb_name],
       'targetSize': 1,
       'capacity': {
@@ -202,7 +202,7 @@ class GoogleServerGroupTestScenario(sk.SpinnakerTestScenario):
       'availabilityZones': {self.TEST_REGION: [self.TEST_ZONE]},
       'cloudProvider': 'gce',
       'source': {
-        'account': self.bindings['GCE_CREDENTIALS'],
+        'account': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
         'region': self.TEST_REGION,
         'zone': self.TEST_ZONE,
         'serverGroupName': self.__server_group_name,
@@ -213,7 +213,7 @@ class GoogleServerGroupTestScenario(sk.SpinnakerTestScenario):
       'initialNumReplicas': 1,
       'loadBalancers': [self.__lb_name],
       'type': 'cloneServerGroup',
-      'account': self.bindings['GCE_CREDENTIALS'],
+      'account': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
       'user': 'integration-tests'
     }]
 
@@ -241,7 +241,7 @@ class GoogleServerGroupTestScenario(sk.SpinnakerTestScenario):
       'type': 'disableServerGroup',
       'regions': [self.TEST_REGION],
       'zones': [self.TEST_ZONE],
-      'credentials': self.bindings['GCE_CREDENTIALS'],
+      'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
       'user': 'integration-tests'
     }]
 
@@ -272,7 +272,7 @@ class GoogleServerGroupTestScenario(sk.SpinnakerTestScenario):
       'type': 'enableServerGroup',
       'regions': [self.TEST_REGION],
       'zones': [self.TEST_ZONE],
-      'credentials': self.bindings['GCE_CREDENTIALS'],
+      'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
       'user': 'integration-tests'
     }]
 
@@ -303,7 +303,7 @@ class GoogleServerGroupTestScenario(sk.SpinnakerTestScenario):
       'type': 'destroyServerGroup',
       'regions': [self.TEST_REGION],
       'zones': [self.TEST_ZONE],
-      'credentials': self.bindings['GCE_CREDENTIALS'],
+      'credentials': self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
       'user': 'integration-tests'
     }]
 
@@ -328,7 +328,7 @@ class GoogleServerGroupTestScenario(sk.SpinnakerTestScenario):
       "region": "us-central1",
       "type": "deleteLoadBalancer",
       "regions": ["us-central1"],
-      "credentials": self.bindings['GCE_CREDENTIALS'],
+      "credentials": self.bindings['SPINNAKER_GOOGLE_ACCOUNT'],
       "cloudProvider": "gce",
       "user": "integration-tests"
     }]

--- a/spinnaker/spinnaker_system/google_smoke_test.py
+++ b/spinnaker/spinnaker_system/google_smoke_test.py
@@ -159,7 +159,7 @@ class GoogleSmokeTestScenario(sk.SpinnakerTestScenario):
             'provider': 'gce',
             'stack': bindings['TEST_STACK'],
             'detail': self.__lb_detail,
-            'credentials': bindings['GCE_CREDENTIALS'],
+            'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
             'region': bindings['TEST_GCE_REGION'],
             'ipProtocol': 'TCP',
             'portRange': spec['port'],
@@ -215,12 +215,12 @@ class GoogleSmokeTestScenario(sk.SpinnakerTestScenario):
             'loadBalancerName': self.__lb_name,
             'region': bindings['TEST_GCE_REGION'],
             'regions': [bindings['TEST_GCE_REGION']],
-            'credentials': bindings['GCE_CREDENTIALS'],
+            'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
             'user': '[anonymous]'
         }],
         description='Delete Load Balancer: {0} in {1}:{2}'.format(
             self.__lb_name,
-            bindings['GCE_CREDENTIALS'],
+            bindings['SPINNAKER_GOOGLE_ACCOUNT'],
             bindings['TEST_GCE_REGION']),
         application=self.TEST_APP)
 
@@ -257,7 +257,7 @@ class GoogleSmokeTestScenario(sk.SpinnakerTestScenario):
         job=[{
             'cloudProvider': 'gce',
             'application': self.TEST_APP,
-            'credentials': bindings['GCE_CREDENTIALS'],
+            'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
             'strategy':'',
             'capacity': {'min':2, 'max':2, 'desired':2},
             'targetSize': 2,
@@ -275,7 +275,7 @@ class GoogleSmokeTestScenario(sk.SpinnakerTestScenario):
                                    ' && sudo apt-get install apache2 -y'),
                 'load-balancer-names': self.__lb_name
             },
-            'account': bindings['GCE_CREDENTIALS'],
+            'account': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
             'authScopes': ['compute'],
             'user': '[anonymous]'
         }],
@@ -315,7 +315,7 @@ class GoogleSmokeTestScenario(sk.SpinnakerTestScenario):
             'type': 'destroyServerGroup',
             'regions': [bindings['TEST_GCE_REGION']],
             'zones': [bindings['TEST_GCE_ZONE']],
-            'credentials': bindings['GCE_CREDENTIALS'],
+            'credentials': bindings['SPINNAKER_GOOGLE_ACCOUNT'],
             'user': '[anonymous]'
         }],
         application=self.TEST_APP,

--- a/spinnaker/spinnaker_system/kube_smoke_test.py
+++ b/spinnaker/spinnaker_system/kube_smoke_test.py
@@ -152,7 +152,7 @@ class KubeSmokeTestScenario(sk.SpinnakerTestScenario):
             'stack': bindings['TEST_STACK'],
             'detail': self.__lb_detail,
             'serviceType': 'ClusterIP',
-            'account': bindings['KUBE_CREDENTIALS'],
+            'account': bindings['SPINNAKER_KUBERNETES_ACCOUNT'],
             'namespace': 'default',
             'ports': [{'protocol':'TCP', 'port':80, 'name':'http'}],
             'externalIps': [],
@@ -191,14 +191,14 @@ class KubeSmokeTestScenario(sk.SpinnakerTestScenario):
             'cloudProvider': 'kubernetes',
             'loadBalancerName': self.__lb_name,
             'namespace': 'default',
-            'account': bindings['KUBE_CREDENTIALS'],
-            'credentials': bindings['KUBE_CREDENTIALS'],
+            'account': bindings['SPINNAKER_KUBERNETES_ACCOUNT'],
+            'credentials': bindings['SPINNAKER_KUBERNETES_ACCOUNT'],
             'regions': ['default'],
             'user': '[anonymous]'
         }],
         description='Delete Load Balancer: {0} in {1}'.format(
             self.__lb_name,
-            bindings['KUBE_CREDENTIALS']),
+            bindings['SPINNAKER_KUBERNETES_ACCOUNT']),
         application=self.TEST_APP)
 
     builder = kube.KubeContractBuilder(self.kube_observer)
@@ -228,7 +228,7 @@ class KubeSmokeTestScenario(sk.SpinnakerTestScenario):
         job=[{
             'cloudProvider': 'kubernetes',
             'application': self.TEST_APP,
-            'account': bindings['KUBE_CREDENTIALS'],
+            'account': bindings['SPINNAKER_KUBERNETES_ACCOUNT'],
             'strategy':'',
             'targetSize': 1,
             'containers': [{
@@ -289,7 +289,7 @@ class KubeSmokeTestScenario(sk.SpinnakerTestScenario):
       'cloudProvider': 'kubernetes',
       'selectionStrategy': 'NEWEST',
       'onlyEnabled': True,
-      'credentials': self.bindings['KUBE_CREDENTIALS'],
+      'credentials': self.bindings['SPINNAKER_KUBERNETES_ACCOUNT'],
       'cluster': frigga.Naming.cluster(
           app=self.TEST_APP, stack=self.bindings['TEST_STACK']),
       'imageNamePattern': self.__desired_image_pattern
@@ -400,8 +400,8 @@ class KubeSmokeTestScenario(sk.SpinnakerTestScenario):
         job=[{
             'cloudProvider': 'kubernetes',
             'type': 'destroyServerGroup',
-            'account': bindings['KUBE_CREDENTIALS'],
-            'credentials': bindings['KUBE_CREDENTIALS'],
+            'account': bindings['SPINNAKER_KUBERNETES_ACCOUNT'],
+            'credentials': bindings['SPINNAKER_KUBEBERNETES_ACCOUNT'],
             'user': '[anonymous]',
             'serverGroupName': group_name,
             'asgName': group_name,

--- a/spinnaker/spinnaker_testing/gate.py
+++ b/spinnaker/spinnaker_testing/gate.py
@@ -204,7 +204,7 @@ class GateAgent(sk.SpinnakerAgent):
     """Create a Gate operation that will create a new application.
 
     Args:
-      bindings: [dict] key/value pairs including GCE_CREDENTIALS
+      bindings: [dict] key/value pairs including SPINNAKER_GOOGLE_ACCOUNT
           and optional TEST_EMAIL.
       application: [string] Name of application to create.
       description: [string] Text description field for the operation payload.
@@ -212,7 +212,7 @@ class GateAgent(sk.SpinnakerAgent):
     Returns:
       AgentOperation.
     """
-    account_name = bindings['GCE_CREDENTIALS']
+    account_name = bindings['SPINNAKER_PRIMARY_ACCOUNT_NAME']
     email = bindings.get('TEST_EMAIL', 'testuser@testhost.org')
     payload = self.make_json_payload_from_kwargs(
         job=[{
@@ -235,14 +235,14 @@ class GateAgent(sk.SpinnakerAgent):
     """Create a Gate operation that will delete an existing application.
 
     Args:
-      bindings: [dict] key/value pairs including GCE_CREDENTIALS
+      bindings: [dict] key/value pairs including SPINNAKER_PRIMARY_ACCOUNT_NAME
           and optional TEST_EMAIL.
       application: [string] Name of application to create.
 
     Returns:
       AgentOperation.
     """
-    account_name = bindings['GCE_CREDENTIALS']
+    account_name = bindings['SPINNAKER_PRIMARY_ACCOUNT_NAME']
     payload = self.make_json_payload_from_kwargs(
         job=[{
             'type': 'deleteApplication',


### PR DESCRIPTION
@jtk54 
This is a first PR preparing to migrate out the spinnaker tests. I
updated some docs and renamed some of the parameters and bindings to
be less daunting and clearer what the parameters are for.

The changes to binding dictionary keys is a breaking change. I'm not
aware of any significant inconvienience this will cause people
(e.g. PRs in progress) The breaking changes are straight forward:
<PLATFORM>_CREDENTIALS -> SPINNAKER_<PLATFORM>_ACCOUNT

The change in parameters is a deprecated change, maintaining support
for the old interface. I'll keep these around of a while since it is
easy to support.