### PR TITLE
L7 upsert test: Make 'add server group' use tags, not security group.

### DIFF
--- a/spinnaker/spinnaker_system/google_http_lb_upsert_scenario.py
+++ b/spinnaker/spinnaker_system/google_http_lb_upsert_scenario.py
@@ -552,6 +552,7 @@ class GoogleHttpLoadBalancerTestScenario(sk.SpinnakerTestScenario):
           'region': 'global',
           'securityGroupName': self.__lb_name + '-rule',
           'sourceRanges': ['0.0.0.0/0'],
+          'targetTags': [self.__lb_name + '-tag'],
           'type': 'upsertSecurityGroup',
           'user': '[anonymous]'
         }
@@ -603,7 +604,7 @@ class GoogleHttpLoadBalancerTestScenario(sk.SpinnakerTestScenario):
         'stack': bindings['TEST_STACK'],
         'instanceType': 'f1-micro',
         'type': 'createServerGroup',
-        'securityGroups': [self.__lb_name + '-rule'],
+        'tags': [self.__lb_name + '-tag'],
         'loadBalancers': [self.__lb_name],
         'backendServices': {self.__lb_name: ['bs-' + self.TEST_APP]},
         'disableTraffic': False,
@@ -661,7 +662,6 @@ class GoogleHttpLoadBalancerTestScenario(sk.SpinnakerTestScenario):
         'serverGroupName': group_name,
         'region': bindings['TEST_GCE_REGION'],
         'zone': bindings['TEST_GCE_ZONE'],
-        'asgName': group_name,
         'type': 'destroyServerGroup',
         'regions': [bindings['TEST_GCE_REGION']],
         'zones': [bindings['TEST_GCE_ZONE']],


### PR DESCRIPTION
@ewiseblatt please review. Creating a server group previously used the `securityGroups` field to specify security groups, but now only uses `tags`. I modified the operation descriptions for creating the security group and server group to use the tags. This should fix the previous test failure.