### PR TITLE
Refactored DICT_MATCH so that it allows multi-level path attributes.

### DIFF
--- a/citest/json_predicate/binary_predicate.py
+++ b/citest/json_predicate/binary_predicate.py
@@ -27,7 +27,7 @@ from . import predicate
 from .keyed_predicate_result import KeyedPredicateResultBuilder
 from .map_predicate import MapPredicate
 from .path_value import PathValue
-from .path_predicate_result import PathPredicateResultBuilder
+from .path_predicate import PathPredicate
 from .path_result import (
     MissingPathError,
     PathValueResult,
@@ -223,18 +223,10 @@ class DictMatchesPredicate(BinaryPredicate):
     match_result_builder = KeyedPredicateResultBuilder(self)
     valid = True
     # pylint: disable=redefined-variable-type
-    for name, pred in self.operand.items():
-      name_value = value.get(name)
-      name_result = None
-      if name_value is None:
-        name_result = MissingPathError(value, name)
-      else:
-        path_result_builder = PathPredicateResultBuilder(
-            source=value, pred=pred)
-        path_result_builder.add_result_candidate(
-            PathValue(name, name_value), pred(context, value.get(name)))
-        name_result = path_result_builder.build()
-
+    for key, pred in self.operand.items():
+      name = context.eval(key)
+      name_result = PathPredicate(key, pred, source_pred=pred,
+                                  enumerate_terminals=False)(context, value)
       if not name_result:
         valid = False
       match_result_builder.add_result(name, name_result)

--- a/citest/json_predicate/map_predicate.py
+++ b/citest/json_predicate/map_predicate.py
@@ -141,6 +141,7 @@ class MapPredicateResult(SequencedPredicateResult):
 
   def __init__(self, valid, pred, obj_list, all_results,
                good_map, bad_map, **kwargs):
+    # pylint: disable=too-many-arguments
     self.__obj_list = obj_list
     self.__good_map = good_map
     self.__bad_map = bad_map
@@ -152,6 +153,21 @@ class MapPredicateResult(SequencedPredicateResult):
             and self.__obj_list == result.obj_list
             and self.__good_map == result.good_object_result_mappings
             and self.__bad_map == result.bad_object_result_mappings)
+
+  def clone_with_source(self, source, base_target_path, base_value_path):
+    """Implements CloneableWithNewSource interface."""
+    builder = MapPredicateResultBuilder(self.pred)
+
+    for index, orig in enumerate(self.results):
+      if isinstance(orig, predicate.CloneableWithNewSource):
+        result = orig.clone_with_source(source=source,
+                                        base_target_path=base_target_path,
+                                        base_value_path=base_value_path)
+      else:
+        result = orig
+      builder.add_result(self.__obj_list[index], result)
+    return builder.build(self.valid)
+
 
 class MapPredicate(predicate.ValuePredicate):
   """Applies a predicate to all elements of a list or a non-list object.


### PR DESCRIPTION
@jtk54 

I also changed PathPredicate to allow configuration of whether or not
to expand list terminals. It defaults to exapand but DICT_MATCh makes
it not. I think this makes it more natural to specify constraints on
attributes, and the feature could be used for PathPredicate cases.