### PR TITLE
Suppress warning from google apiclient.

### DIFF
--- a/citest/gcp_testing/gcp_agent.py
+++ b/citest/gcp_testing/gcp_agent.py
@@ -28,6 +28,12 @@ from ..base import JournalLogger
 from ..service_testing import BaseAgent
 import citest
 
+# This doesnt belong here, but this library insists on logging
+# ImportError: file_cache is unavailable when using oauth2client >= 4.0.0
+# The maintainer wont fix or remove the warning so we'll force it to be disabled
+logging.getLogger('googleapiclient.discovery_cache').setLevel(logging.ERROR)
+
+
 PLATFORM_READ_ONLY_SCOPE = (
     'https://www.googleapis.com/auth/cloud-platform.read-only'
     )


### PR DESCRIPTION
@ttomsu 
This works around the problem you were seeing last week.
I dont like it, but dont see a way to force every different script to update.
